### PR TITLE
## [0.16.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # KdbInsideBrains Changelog
 
+## [0.16.0]
+
+### Changed
+
+- Excel exporting format changed to xlsx (Excel 2007) instead of xls (Excel 95)
+  - 1,048,576 rows instead of 65,536 and 16,384 cols instead of 256
+  - Streams worksheet is used to reduce memory footprint
+
+- Export actions run as a background task to reduce UI freeze
+
 ## [0.15.0]
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,10 @@ generateParser {
 }
 
 dependencies {
-    compile 'org.apache.poi:poi:5.0.0'
+    compile 'org.apache.poi:poi:5.1.0'
+    compile 'org.apache.poi:poi-ooxml:5.1.0'
 
-    testCompile 'org.mockito:mockito-core:4.1.0'
+    testCompile 'org.mockito:mockito-core:4.2.0'
 
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/src/main/java/org/kdb/inside/brains/psi/QImport.java
+++ b/src/main/java/org/kdb/inside/brains/psi/QImport.java
@@ -28,7 +28,7 @@ public interface QImport extends QPsiElement, NavigatablePsiElement {
         while (Character.isWhitespace(text.charAt(e))) {
             e--;
         }
-        if (e == l) {
+        if (e == l || e + 1 <= s) {
             return TextRange.EMPTY_RANGE;
         }
         return new TextRange(s, e + 1);

--- a/src/main/java/org/kdb/inside/brains/view/console/export/AnExportAction.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/export/AnExportAction.java
@@ -2,15 +2,22 @@ package org.kdb.inside.brains.view.console.export;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.progress.PerformInBackgroundOption;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.ui.tabs.JBTabs;
+import com.intellij.ui.tabs.TabInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.kdb.inside.brains.view.console.TableResultView;
 
 import javax.swing.*;
+import java.awt.*;
+import java.io.IOException;
 
-public abstract class AnExportAction extends AnAction {
+public abstract class AnExportAction<Config> extends AnAction {
     private final ExportingType type;
     private final TableResultView resultView;
 
@@ -29,6 +36,16 @@ public abstract class AnExportAction extends AnAction {
     }
 
     @Override
+    public void update(@NotNull AnActionEvent e) {
+        final TableResultView view = getTableResultView(e);
+        if (view == null) {
+            e.getPresentation().setEnabled(false);
+        } else {
+            e.getPresentation().setEnabled(type.hasExportingData(view));
+        }
+    }
+
+    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         final Project project = e.getProject();
         final TableResultView view = getTableResultView(e);
@@ -43,21 +60,49 @@ public abstract class AnExportAction extends AnAction {
             return;
         }
 
+        final Config config;
         try {
-            performAction(project, view, type);
+            config = getExportConfig(project, view);
+            if (config == null) {
+                return;
+            }
         } catch (Exception ex) {
             Messages.showErrorDialog(project, ex.getMessage(), "Data Can't Be Exported");
+            return;
         }
+
+        final String title = "Exporting " + getExportingName(view);
+        new Task.Backgroundable(project, title, isCancelable(), PerformInBackgroundOption.DEAF) {
+            @Override
+            public void run(@NotNull ProgressIndicator indicator) {
+                try {
+                    exportResultView(project, type, view, config, indicator);
+                } catch (Exception ex) {
+                    Messages.showErrorDialog(project, ex.getMessage(), "Data Can't Be Exported");
+                }
+            }
+        }.queue();
     }
 
-    @Override
-    public void update(@NotNull AnActionEvent e) {
-        final TableResultView view = getTableResultView(e);
-        if (view == null) {
-            e.getPresentation().setEnabled(false);
-        } else {
-            e.getPresentation().setEnabled(type.hasExportingData(view));
+    protected boolean isCancelable() {
+        return true;
+    }
+
+    protected abstract Config getExportConfig(Project project, TableResultView view) throws IOException;
+
+    protected abstract void exportResultView(Project project, ExportingType type, TableResultView view, Config config, @NotNull ProgressIndicator indicator) throws Exception;
+
+    private String getExportingName(TableResultView view) {
+        final Container parent = view.getParent();
+        if (parent instanceof JBTabs) {
+            final JBTabs jbTabs = (JBTabs) parent;
+            for (TabInfo info : jbTabs.getTabs()) {
+                if (info.getObject() == view) {
+                    return info.getText();
+                }
+            }
         }
+        return "Table Result";
     }
 
     @Nullable
@@ -67,6 +112,4 @@ public abstract class AnExportAction extends AnAction {
         }
         return TableResultView.DATA_KEY.getData(e.getDataContext());
     }
-
-    protected abstract void performAction(Project project, TableResultView view, ExportingType type) throws Exception;
 }

--- a/src/main/java/org/kdb/inside/brains/view/console/export/BinaryExportAction.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/export/BinaryExportAction.java
@@ -3,36 +3,40 @@ package org.kdb.inside.brains.view.console.export;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.fileChooser.FileSaverDescriptor;
 import com.intellij.openapi.fileChooser.FileSaverDialog;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileWrapper;
 import kx.c;
+import org.jetbrains.annotations.NotNull;
 import org.kdb.inside.brains.view.console.TableResultView;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-public class BinaryExportAction extends AnExportAction {
+public class BinaryExportAction extends AnExportAction<VirtualFileWrapper> {
     public BinaryExportAction(String text, ExportingType type, TableResultView resultView, String description) {
         super(text, type, resultView, description);
     }
 
     @Override
-    protected void performAction(Project project, TableResultView view, ExportingType type) throws IOException {
-        final FileSaverDescriptor fileSaverDescriptor = new FileSaverDescriptor("Export to KDB Binary", "Exporting data into native KDB IPC format", "data");
-        final FileSaverDialog saveFileDialog = FileChooserFactory.getInstance().createSaveFileDialog(fileSaverDescriptor, project);
-        final VirtualFileWrapper file = saveFileDialog.save((VirtualFile) null, "Table Result");
-        if (file != null) {
-            exportData(file.getFile(), view, type);
-        }
-
+    protected boolean isCancelable() {
+        return false;
     }
 
-    private void exportData(File file, TableResultView view, ExportingType type) throws IOException {
-        final Object nativeObject = view.getTableResult().getResult().getObject();
+    @Override
+    protected VirtualFileWrapper getExportConfig(Project project, TableResultView view) {
+        final FileSaverDescriptor fileSaverDescriptor = new FileSaverDescriptor("Export to KDB Binary", "Exporting data into native KDB IPC format", "data");
+        final FileSaverDialog saveFileDialog = FileChooserFactory.getInstance().createSaveFileDialog(fileSaverDescriptor, project);
+        return saveFileDialog.save((VirtualFile) null, "Table Result");
+    }
 
+    @Override
+    protected void exportResultView(Project project, ExportingType type, TableResultView view, VirtualFileWrapper file, @NotNull ProgressIndicator indicator) throws IOException {
+        indicator.setIndeterminate(true);
+
+        final Object nativeObject = view.getTableResult().getResult().getObject();
         final byte[] serialize = new c().serialize(0, nativeObject, true);
-        Files.write(file.toPath(), serialize);
+        Files.write(file.getFile().toPath(), serialize);
     }
 }

--- a/src/main/java/org/kdb/inside/brains/view/console/export/CsvExportAction.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/export/CsvExportAction.java
@@ -4,10 +4,12 @@ import com.google.common.primitives.Primitives;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.fileChooser.FileSaverDescriptor;
 import com.intellij.openapi.fileChooser.FileSaverDialog;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileWrapper;
 import com.intellij.ui.table.JBTable;
+import org.jetbrains.annotations.NotNull;
 import org.kdb.inside.brains.view.console.TableResultView;
 
 import java.io.File;
@@ -15,22 +17,24 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
-public class CsvExportAction extends AnExportAction {
+public class CsvExportAction extends AnExportAction<VirtualFileWrapper> {
     public CsvExportAction(String text, ExportingType type, TableResultView resultView, String description) {
         super(text, type, resultView, description);
     }
 
     @Override
-    protected void performAction(Project project, TableResultView view, ExportingType type) throws IOException {
+    protected VirtualFileWrapper getExportConfig(Project project, TableResultView view) {
         final FileSaverDescriptor fileSaverDescriptor = new FileSaverDescriptor("Export to CSV", "Exporting data into tab separated file format", "csv");
         final FileSaverDialog saveFileDialog = FileChooserFactory.getInstance().createSaveFileDialog(fileSaverDescriptor, project);
-        final VirtualFileWrapper file = saveFileDialog.save((VirtualFile) null, "Table Result");
-        if (file != null) {
-            exportData(file.getFile(), view, type);
-        }
+        return saveFileDialog.save((VirtualFile) null, "Table Result");
     }
 
-    private void exportData(File file, TableResultView view, ExportingType type) throws IOException {
+    @Override
+    protected void exportResultView(Project project, ExportingType type, TableResultView view, VirtualFileWrapper file, @NotNull ProgressIndicator indicator) throws IOException {
+        exportData(file.getFile(), view, type, indicator);
+    }
+
+    private void exportData(File file, TableResultView view, ExportingType type, @NotNull ProgressIndicator indicator) throws IOException {
         final JBTable table = view.getTable();
 
         final StringBuilder plainStr = new StringBuilder();
@@ -46,14 +50,22 @@ public class CsvExportAction extends AnExportAction {
             plainStr.deleteCharAt(plainStr.length() - 1).append('\n');
         }
 
-        for (int r = ri.reset(); r != -1; r = ri.next()) {
+        int count = 0;
+        double totalCount = ri.count() * ci.count();
+        indicator.setIndeterminate(false);
+        for (int r = ri.reset(); r != -1 && !indicator.isCanceled(); r = ri.next()) {
             ci.reset();
-            for (int c = ci.reset(); c != -1; c = ci.next()) {
+            for (int c = ci.reset(); c != -1 && !indicator.isCanceled(); c = ci.next()) {
                 final Object val = getValueAt(table, view, r, c);
                 plainStr.append(val).append('\t');
+                indicator.setFraction(count++ / totalCount);
             }
             // we want a newline at the end of each line and not a tab
             plainStr.deleteCharAt(plainStr.length() - 1).append('\n');
+        }
+
+        if (indicator.isCanceled()) {
+            return;
         }
 
         // remove the last newline

--- a/src/main/java/org/kdb/inside/brains/view/console/export/ExcelExportAction.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/export/ExcelExportAction.java
@@ -3,21 +3,27 @@ package org.kdb.inside.brains.view.console.export;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.fileChooser.FileSaverDescriptor;
 import com.intellij.openapi.fileChooser.FileSaverDialog;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileWrapper;
 import com.intellij.ui.table.JBTable;
 import icons.KdbIcons;
 import kx.KxConnection;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.jetbrains.annotations.NotNull;
 import org.kdb.inside.brains.view.console.TableResultView;
 
 import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 
-public class ExcelExportAction extends AnExportAction {
+public class ExcelExportAction extends AnExportAction<File> {
     private final boolean saveOnDisk;
 
     public ExcelExportAction(String text, ExportingType type, TableResultView resultView, String description, boolean saveOnDisk) {
@@ -27,66 +33,80 @@ public class ExcelExportAction extends AnExportAction {
     public ExcelExportAction(String text, ExportingType type, TableResultView resultView, String description, boolean saveOnDisk, Icon icon) {
         super(text, type, resultView, description, icon);
         this.saveOnDisk = saveOnDisk;
+
+
     }
 
     @Override
-    protected void performAction(Project project, TableResultView view, ExportingType type) throws Exception {
+    protected File getExportConfig(Project project, TableResultView view) throws IOException {
         if (saveOnDisk) {
-            final FileSaverDescriptor fileSaverDescriptor = new FileSaverDescriptor("Export to Excel", "Exporting data into Excel file format", "xls");
+            final FileSaverDescriptor fileSaverDescriptor = new FileSaverDescriptor("Export to Excel", "Exporting data into Excel file format", "xlsx");
             final FileSaverDialog saveFileDialog = FileChooserFactory.getInstance().createSaveFileDialog(fileSaverDescriptor, project);
 
-            final VirtualFileWrapper file = saveFileDialog.save((VirtualFile) null, "Table Result");
-            if (file != null) {
-                exportData(file.getFile(), view, type);
-            }
+            final VirtualFileWrapper vfw = saveFileDialog.save((VirtualFile) null, "Table Result");
+            return vfw == null ? null : vfw.getFile();
         } else {
-            final File f = File.createTempFile("kdbinsidebrains_exel_export_", ".xls");
-            exportData(f, view, type);
-            Desktop.getDesktop().open(f);
+            return File.createTempFile("kdbinsidebrains_exel_export_", ".xlsx");
         }
     }
 
-    private void exportData(File file, TableResultView view, ExportingType type) throws Exception {
-        final Workbook wb = WorkbookFactory.create(false);
-        final Sheet sheet = wb.createSheet("KDB Exported Data");
-
-        final JBTable table = view.getTable();
-        final ExportingType.IndexIterator ri = type.rowsIterator(table);
-        final ExportingType.IndexIterator ci = type.columnsIterator(table);
-
-        int index = 0;
-        if (type.withHeader()) {
-            Row row = sheet.createRow(index++);
-
-            int i = 0;
-            for (int c = ci.reset(); c != -1; c = ci.next()) {
-                final String columnName = table.getColumnName(c);
-                row.createCell(i++, CellType.STRING).setCellValue(columnName);
-            }
+    @Override
+    protected void exportResultView(Project project, ExportingType type, TableResultView view, File file, @NotNull ProgressIndicator indicator) throws Exception {
+        if (exportData(file, view, type, indicator)) {
+            Desktop.getDesktop().open(file);
         }
+    }
 
-        for (int r = ri.reset(); r != -1; r = ri.next()) {
-            final Row row = sheet.createRow(index++);
-            int i = 0;
-            for (int c = ci.reset(); c != -1; c = ci.next()) {
-                final Object value = table.getValueAt(r, c);
-                if (value instanceof Boolean) {
-                    row.createCell(i++, CellType.BOOLEAN).setCellValue((Boolean) value);
-                } else if (value instanceof Number) {
-                    if (KxConnection.isNull(value)) {
-                        row.createCell(i++, CellType.NUMERIC).setCellValue(view.convertValue(value));
-                    } else {
-                        row.createCell(i++, CellType.NUMERIC).setCellValue(((Number) value).doubleValue());
-                    }
-                } else {
-                    row.createCell(i++).setCellValue(view.convertValue(value));
+    private boolean exportData(File file, TableResultView view, ExportingType type, @NotNull ProgressIndicator indicator) throws Exception {
+        try (final SXSSFWorkbook wb = new SXSSFWorkbook(null, 100, false, true)) {
+            final Sheet sheet = wb.createSheet("KDB Exported Data");
+
+            final JBTable table = view.getTable();
+            final ExportingType.IndexIterator ri = type.rowsIterator(table);
+            final ExportingType.IndexIterator ci = type.columnsIterator(table);
+
+            int index = 0;
+            if (type.withHeader()) {
+                Row row = sheet.createRow(index++);
+
+                int i = 0;
+                for (int c = ci.reset(); c != -1; c = ci.next()) {
+                    final String columnName = table.getColumnName(c);
+                    row.createCell(i++, CellType.STRING).setCellValue(columnName);
                 }
             }
-        }
 
-        try (final FileOutputStream stream = new FileOutputStream(file)) {
-            wb.write(stream);
+            int count = 0;
+            double totalCount = ri.count() * ci.count();
+            indicator.setIndeterminate(false);
+            for (int r = ri.reset(); r != -1 && !indicator.isCanceled(); r = ri.next()) {
+                final Row row = sheet.createRow(index++);
+                int i = 0;
+                for (int c = ci.reset(); c != -1 && !indicator.isCanceled(); c = ci.next()) {
+                    final Object value = table.getValueAt(r, c);
+                    if (value instanceof Boolean) {
+                        row.createCell(i++, CellType.BOOLEAN).setCellValue((Boolean) value);
+                    } else if (value instanceof Number) {
+                        if (KxConnection.isNull(value)) {
+                            row.createCell(i++, CellType.NUMERIC).setCellValue(view.convertValue(value));
+                        } else {
+                            row.createCell(i++, CellType.NUMERIC).setCellValue(((Number) value).doubleValue());
+                        }
+                    } else {
+                        row.createCell(i++).setCellValue(view.convertValue(value));
+                    }
+                    indicator.setFraction(count++ / totalCount);
+                }
+            }
+
+            if (indicator.isCanceled()) {
+                return false;
+            }
+
+            try (final FileOutputStream stream = new FileOutputStream(file)) {
+                wb.write(stream);
+            }
+            return true;
         }
-        wb.close();
     }
 }

--- a/src/main/java/org/kdb/inside/brains/view/console/export/ExportingType.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/export/ExportingType.java
@@ -87,6 +87,11 @@ public enum ExportingType {
                 maxIndex = iterateAllIndexes ? totalMax : selectionModel.getMaxSelectionIndex();
                 return next();
             }
+
+            @Override
+            public int count() {
+                return totalMax;
+            }
         };
     }
 
@@ -94,5 +99,7 @@ public enum ExportingType {
         int next();
 
         int reset();
+
+        int count();
     }
 }

--- a/src/main/resources/org/kdb/inside/brains/q.bnf
+++ b/src/main/resources/org/kdb/inside/brains/q.bnf
@@ -107,11 +107,9 @@ command ::= COMMAND_SYSTEM  command_params? { pin = 1 methods = [command="COMMAN
 private command_params ::= COMMAND_ARGUMENTS {recoverWhile = end_of_line_recover}
 
 import_command ::= COMMAND_IMPORT import_command_file { pin = 1 implements="org.kdb.inside.brains.psi.QImport" }
-
-import_function ::= FUNCTION_IMPORT import_function_file { pin = 1 extends=expression implements="org.kdb.inside.brains.psi.QImport" }
-
 private import_command_file ::= FILE_PATH_PATTERN {recoverWhile = end_of_line_recover }
-private import_function_file ::= STRING
+
+import_function ::= FUNCTION_IMPORT expression { pin = 1 extends=expression implements="org.kdb.inside.brains.psi.QImport" }
 
 // In mode we can't use LINE_BREAK as a separator
 private mode_content ::= statement+ { recoverWhile = end_of_line_recover }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-pluginVersion=0.15.0
+pluginVersion=0.16.0


### PR DESCRIPTION
### Changed

- Excel exporting format changed to xlsx (Excel 2007) instead of xls (Excel 95)
  - 1,048,576 rows instead of 65,536 and 16,384 cols instead of 256
  - Streams worksheet is used to reduce memory footprint

- Export actions run as a background task to reduce UI freeze