### PR TITLE
- Hovering for striped tables is not shown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 # KdbInsideBrains Changelog
 
+## [0.23.0]
+
+### Fixed
+
+- Hovering for striped tables is not shown.
+- TableView background is not correct if 'stripe table' is disabled for keyed tables.
+- Disabling 'wrap string' option also disables 'Stripe table' option.
+- Key column symbol is not shown for keyed table but dictionary.
+
 ## [0.22.0]
 
 ### Added
@@ -57,8 +66,8 @@
   - **Crosshair tool** - to show current values for the mouse position
   - **Measure tool** - draw measuring rectangles on the chart with values diff: left mouse click to start, move, left
     mouse click to finish. Esc to cancel current drawing.
-  - **Points collector** - save any chart clicked values into the points collector table with ability to export or
-    send into another KDB instance.
+  - **Points collector** - save any chart clicked values into the points collector table with ability to export or send
+    into another KDB instance.
 
 ## [0.18.1]
 

--- a/src/main/java/org/kdb/inside/brains/view/KdbOutputFormatter.java
+++ b/src/main/java/org/kdb/inside/brains/view/KdbOutputFormatter.java
@@ -8,7 +8,6 @@ import org.kdb.inside.brains.core.KdbResult;
 import org.kdb.inside.brains.settings.KdbSettingsService;
 import org.kdb.inside.brains.view.console.ConsoleOptions;
 
-import javax.swing.table.DefaultTableCellRenderer;
 import java.lang.reflect.Array;
 import java.sql.Date;
 import java.sql.Time;
@@ -57,46 +56,12 @@ public final class KdbOutputFormatter {
         return formatObject(object);
     }
 
-    public DefaultTableCellRenderer createCellRenderer() {
-        return createCellRenderer(true);
-    }
-
-    public DefaultTableCellRenderer createCellRenderer(boolean useOptions) {
-        return new DefaultTableCellRenderer() {
-            @Override
-            protected void setValue(Object value) {
-                setText(valueToString(value));
-            }
-
-            private String valueToString(Object value) {
-                if (useOptions) {
-                    if (value instanceof String && !options.isPrefixSymbols()) {
-                        return String.valueOf(value);
-                    } else if (value instanceof char[] && !options.isWrapStrings()) {
-                        return new String((char[]) value);
-                    } else if (value instanceof Character && !options.isWrapStrings()) {
-                        return String.valueOf(value);
-                    }
-                }
-                return formatObject(value);
-            }
-        };
-    }
-
     public static KdbOutputFormatter getInstance() {
         if (instance == null) {
             instance = new KdbOutputFormatter(KdbSettingsService.getInstance().getConsoleOptions());
         }
         return instance;
     }
-
-    /*
-
-    public String convertResult(KdbResult result) {
-        return convertObject(result.getObject());
-    }
-*/
-
 
     private String formatObject(Object v) {
         if (v == null) {

--- a/src/main/java/org/kdb/inside/brains/view/console/ConsoleOptionsPanel.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/ConsoleOptionsPanel.java
@@ -42,7 +42,7 @@ public class ConsoleOptionsPanel extends JPanel {
         consoleOptions.setFloatPrecision(floatPrecisionEditor.getNumber());
         consoleOptions.setWrapStrings(wrapString.isSelected());
         consoleOptions.setPrefixSymbols(prefixSymbols.isSelected());
-        consoleOptions.setStriped(wrapString.isSelected());
+        consoleOptions.setStriped(striped.isSelected());
         consoleOptions.setShowGrid(showGrid.isSelected());
         consoleOptions.setListAsTable(listAsTable.isSelected());
         consoleOptions.setDictAsTable(dictAsTable.isSelected());

--- a/src/main/java/org/kdb/inside/brains/view/console/TableResult.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/TableResult.java
@@ -222,7 +222,7 @@ public class TableResult {
 
         @SuppressWarnings("unchecked")
         public QColumnInfo(String name, Class<?> columnClass, boolean key) {
-            super(name);
+            super((key ? KEY_COLUMN_PREFIX : "") + name);
             this.key = key;
             this.columnClass = columnClass;
 
@@ -255,7 +255,7 @@ public class TableResult {
 
         static QColumnInfo[] of(c.Dict dict) {
             return new QColumnInfo[]{
-                    new QColumnInfo(KEY_COLUMN_PREFIX + "Key", dict.x.getClass().getComponentType(), true),
+                    new QColumnInfo("Key", dict.x.getClass().getComponentType(), true),
                     new QColumnInfo("Value", dict.y.getClass().getComponentType(), false)
             };
         }

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-pluginVersion=0.22.0
+pluginVersion=0.23.0


### PR DESCRIPTION
- TableView background is not correct if 'stripe table' is disabled for keyed tables.
- Disabling 'wrap string' option also disables 'Stripe table' option.
- Key column symbol is not shown for keyed table but dictionary.