### PR TITLE
v 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # KdbInsideBrains Changelog
 
+## [1.6.1]
+
+### Fixed
+
+- Items are auto-expanded at search in InstanceTree
+- Max decimal precisions is 16 digits now and size is limited by the spinner in the settings
+- Export to Excel and CSV ignores symbol and string wrapping options and export only raw data
+- Nulls in Excel exported as empty value
+- Copy/Paste takes into account symbol and string wrapping options
+
 ## [1.6.0]
 
 ### Added

--- a/src/main/java/org/kdb/inside/brains/action/ExecuteInlineAction.java
+++ b/src/main/java/org/kdb/inside/brains/action/ExecuteInlineAction.java
@@ -102,7 +102,7 @@ public class ExecuteInlineAction extends ExecuteAction implements DumbAware {
                     if (tableResult != null) {
                         showTypedHint(createTableHint(project, formatter, tableResult), editor);
                     } else {
-                        showTypedHint(createTextHint(formatter.resultToString(res), false), editor);
+                        showTypedHint(createTextHint(formatter.resultToString(res, true, true), false), editor);
                     }
                 }
             });

--- a/src/main/java/org/kdb/inside/brains/view/console/ConsoleOptions.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/ConsoleOptions.java
@@ -15,7 +15,7 @@ public final class ConsoleOptions implements SettingsBean<ConsoleOptions> {
     private boolean listAsTable = true;
     private ConsoleSplitType splitType = ConsoleSplitType.NO;
 
-    public static final int MAX_DECIMAL_PRECISION = 15;
+    public static final int MAX_DECIMAL_PRECISION = 16;
 
     public ConsoleOptions() {
     }

--- a/src/main/java/org/kdb/inside/brains/view/console/ConsoleOptionsPanel.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/ConsoleOptionsPanel.java
@@ -17,7 +17,7 @@ public class ConsoleOptionsPanel extends JPanel {
     private final JBCheckBox striped = new JBCheckBox("Stripe table rows");
     private final JBCheckBox listAsTable = new JBCheckBox("Show list as table");
     private final JBCheckBox dictAsTable = new JBCheckBox("Show dict as table");
-    private final JBIntSpinner floatPrecisionEditor = new JBIntSpinner(7, 0, 20);
+    private final JBIntSpinner floatPrecisionEditor = new JBIntSpinner(7, 0, ConsoleOptions.MAX_DECIMAL_PRECISION);
     private final ComboBox<ConsoleSplitType> splitTypes = new ComboBox<>(ConsoleSplitType.values());
 
     public ConsoleOptionsPanel() {

--- a/src/main/java/org/kdb/inside/brains/view/console/KdbConsolePanel.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/KdbConsolePanel.java
@@ -460,7 +460,7 @@ public class KdbConsolePanel extends SimpleToolWindowPanel implements DataProvid
                     showConsoleResult();
                 } else {
                     printRoundtrip(result);
-                    printToConsole(formatter.resultToString(result) + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
+                    printToConsole(formatter.resultToString(result, true, true) + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
 
                     final TableResult tbl = TableResult.from(query, result);
                     if (tbl != null) {

--- a/src/main/java/org/kdb/inside/brains/view/console/TableResultView.java
+++ b/src/main/java/org/kdb/inside/brains/view/console/TableResultView.java
@@ -76,18 +76,7 @@ public class TableResultView extends NonOpaquePanel implements DataProvider, Exp
 
             @Override
             protected void setValue(Object value) {
-                setText(valueToString(value));
-            }
-
-            private String valueToString(Object value) {
-                if (value instanceof String && !options.isPrefixSymbols()) {
-                    return String.valueOf(value);
-                } else if (value instanceof char[] && !options.isWrapStrings()) {
-                    return new String((char[]) value);
-                } else if (value instanceof Character && !options.isWrapStrings()) {
-                    return String.valueOf(value);
-                }
-                return formatter.objectToString(value);
+                setText(formatter.objectToString(value));
             }
         };
 

--- a/src/main/java/org/kdb/inside/brains/view/export/CsvExportAction.java
+++ b/src/main/java/org/kdb/inside/brains/view/export/CsvExportAction.java
@@ -77,6 +77,6 @@ public class CsvExportAction extends AnExportAction<VirtualFileWrapper> {
         if (Primitives.isWrapperType(valueAt.getClass())) {
             return valueAt;
         }
-        return '"' + formatter.objectToString(valueAt).replace("\"", "\"\"") + '"';
+        return '"' + formatter.objectToString(valueAt, false, false).replace("\"", "\"\"") + '"';
     }
 }

--- a/src/main/java/org/kdb/inside/brains/view/treeview/tree/InstancesSpeedSearch.java
+++ b/src/main/java/org/kdb/inside/brains/view/treeview/tree/InstancesSpeedSearch.java
@@ -1,0 +1,86 @@
+package org.kdb.inside.brains.view.treeview.tree;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.ui.SpeedSearchComparator;
+import com.intellij.ui.TreeSpeedSearch;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.kdb.inside.brains.core.KdbInstance;
+
+import javax.swing.*;
+import javax.swing.tree.TreePath;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InstancesSpeedSearch extends TreeSpeedSearch {
+    private final TheSpeedSearchComparator comparator = new TheSpeedSearchComparator();
+
+    private InstancesSpeedSearch(JTree tree) {
+        super(tree, InstancesSpeedSearch::pathToString, true);
+        setComparator(comparator);
+    }
+
+    private static String pathToString(TreePath path) {
+        return itemToString(path.getLastPathComponent());
+    }
+
+    private static String itemToString(Object c) {
+        if (c instanceof KdbInstance) {
+            final KdbInstance i = (KdbInstance) c;
+            return i.getCanonicalName() + " " + i.toSymbol();
+        }
+        return c.toString();
+    }
+
+    public static void install(JTree tree) {
+        new InstancesSpeedSearch(tree);
+    }
+
+    @Override
+    protected boolean compare(@NotNull String text, @Nullable String pattern) {
+        if (pattern == null) {
+            return false;
+        }
+        return comparator.matchingFragmentsStrict(pattern, text, true) != null;
+    }
+
+    public boolean isObjectFilteredOut(Object o) {
+        final String str = itemToString(o);
+        return str == null || !compare(str, comparator.getRecentSearchText());
+    }
+
+    private static class TheSpeedSearchComparator extends SpeedSearchComparator {
+        @Override
+        public int matchingDegree(String pattern, String text) {
+            return matchingFragments(pattern, text) != null ? 1 : 0;
+        }
+
+        @Override
+        public Iterable<TextRange> matchingFragments(@NotNull String pattern, @NotNull String text) {
+            return matchingFragmentsStrict(pattern, text, false);
+        }
+
+        private List<TextRange> matchingFragmentsStrict(@NotNull String pattern, @NotNull String text, boolean strict) {
+            myRecentSearchText = pattern;
+
+            final String[] strings = pattern.split(" ");
+            if (strings.length == 0) {
+                return List.of();
+            }
+
+            final ArrayList<TextRange> r = new ArrayList<>(strings.length);
+            for (String token : strings) {
+                int index = StringUtil.indexOfIgnoreCase(text, token, 0);
+                if (index < 0) {
+                    if (strict) {
+                        return null;
+                    }
+                } else {
+                    r.add(TextRange.from(index, token.length()));
+                }
+            }
+            return r;
+        }
+    }
+}

--- a/src/main/java/org/kdb/inside/brains/view/treeview/tree/InstancesTree.java
+++ b/src/main/java/org/kdb/inside/brains/view/treeview/tree/InstancesTree.java
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.ui.PopupHandler;
-import com.intellij.ui.TreeSpeedSearch;
 import com.intellij.ui.awt.RelativeRectangle;
 import com.intellij.util.NullableFunction;
 import com.intellij.util.ui.tree.TreeUtil;
@@ -78,11 +77,12 @@ public class InstancesTree extends DnDAwareTree implements DnDTargetChecker, DnD
 
         PopupHandler.installPopupHandler(this, "Kdb.InstancesScopeView", ActionPlaces.getActionGroupPopupPlace(ActionPlaces.INSTANCES_VIEW_POPUP));
 
-        new TreeSpeedSearch(this);
+        InstancesSpeedSearch.install(this);
 
         ToolTipManager.sharedInstance().registerComponent(this);
 
         enableDnD();
+
         initListeners();
     }
 

--- a/src/main/java/org/kdb/inside/brains/view/treeview/tree/InstancesTreeRenderer.java
+++ b/src/main/java/org/kdb/inside/brains/view/treeview/tree/InstancesTreeRenderer.java
@@ -4,6 +4,7 @@ import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.LoadingNode;
 import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.speedSearch.SpeedSearchUtil;
 import com.intellij.util.text.DateFormatUtil;
 import icons.KdbIcons;
 import org.jetbrains.annotations.NotNull;
@@ -19,6 +20,7 @@ public class InstancesTreeRenderer extends ColoredTreeCellRenderer {
 
     public InstancesTreeRenderer(KdbConnectionManager manager) {
         this.manager = manager;
+        this.myUsedCustomSpeedSearchHighlighting = true;
     }
 
     @Override
@@ -40,6 +42,8 @@ public class InstancesTreeRenderer extends ColoredTreeCellRenderer {
         } else if (item instanceof KdbInstance) {
             instanceRenderer((KdbInstance) item, cutting);
         }
+
+        SpeedSearchUtil.applySpeedSearchHighlightingFiltered(tree, value, this, false, selected);
     }
 
     private void scopeRenderer(KdbScope scope) {

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-pluginVersion=1.6.0
+pluginVersion=1.6.1


### PR DESCRIPTION
- Items are auto-expanded at search in InstanceTree
- Max decimal precisions is 16 digits now and size is limited by the spinner in the settings
- Export to Excel and CSV ignores symbol and string wrapping options and export only raw data
- Nulls in Excel exported as empty value
- Copy/Paste takes into account symbol and string wrapping options