### PR TITLE
Invalid directory message when setting SDK on MacOS

### DIFF
--- a/src/main/java/org/kdb/inside/brains/ide/sdk/KdbSdkType.java
+++ b/src/main/java/org/kdb/inside/brains/ide/sdk/KdbSdkType.java
@@ -164,6 +164,9 @@ public class KdbSdkType extends SdkType {
                 if (isLinux() && file.getName().equals("q")) {
                     return file;
                 }
+                if (isMacOS() && file.getName().equals("q")) {
+                    return file;
+                }
             }
         }
         return null;
@@ -175,5 +178,8 @@ public class KdbSdkType extends SdkType {
 
     private static boolean isWindows() {
         return SystemUtils.IS_OS_WINDOWS;
+    }
+    private static boolean isMacOS() {
+        return SystemUtils.IS_OS_MAC;
     }
 }


### PR DESCRIPTION
Hello :)

The issue was that on MacOS I couldn't set an SDK because I got an error saying that I have an invalid SDK directory.
The pull request fixes this issue and at first glance plugin started working properly.