### PR TITLE
5.8.3: Mode parsing fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # KdbInsideBrains Changelog
 
+## [5.8.3]
+
+### Fixed
+
+- Issues 101: mode highlighting is used for a variable at the end of line sometimes
+
 ## [5.8.2]
 
 ### Fixed

--- a/src/main/resources/org/kdb/inside/brains/q.flex
+++ b/src/main/resources/org/kdb/inside/brains/q.flex
@@ -2,13 +2,12 @@ package org.kdb.inside.brains;
 
 import com.intellij.psi.tree.IElementType;
 
-import java.util.Deque;
 import java.util.ArrayDeque;
-
-import static org.kdb.inside.brains.psi.QTypes.*;
+import java.util.Deque;
 
 import static com.intellij.psi.TokenType.BAD_CHARACTER;
 import static com.intellij.psi.TokenType.WHITE_SPACE;
+import static org.kdb.inside.brains.psi.QTypes.*;
 
 %%
 
@@ -318,7 +317,7 @@ Vector={BooleanList}|{ByteList}|{IntegerList}|{FloatList}|
   ^{CommandName}/{NewLine}                   { return COMMAND_SYSTEM; }
   ^{CommandName}/{WhiteSpace}                { return COMMAND_SYSTEM; }
 
-  ^{ModePrefix}                              { return MODE_PATTERN; }
+  ^{ModePrefix}                              { if (zzCurrentPos == 0 || zzBuffer.charAt(zzCurrentPos - 1) == '\n') {return MODE_PATTERN; } else {yypushback(1); return VARIABLE_PATTERN;} }
 
   {TypeCast}                                 { return TYPE_CAST_PATTERN; }
 

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-pluginVersion=5.8.2
+pluginVersion=5.8.3


### PR DESCRIPTION
In a simple construction (count x) it happens after each second space placed at the end of the line. It's related to IDEA syntax highlighting optimization when only last part of a text is passed to the Lexer analyzer and as x) starts with start of line - it's wrongly identified as a MODE token.

Solution - check that previous char is start of file or new line. If not - it's a variable ([a-zA-Z] can be only variable here).