### PR TITLE
Dead-connection detection: tuned TCP keepalive, idle heartbeat with watchdog, optional auto-reconnect

### DIFF
--- a/src/main/java/kx/KxConnection.java
+++ b/src/main/java/kx/KxConnection.java
@@ -41,22 +41,26 @@ public class KxConnection extends c implements Closeable {
     }
 
     public Object query(Object x, CancellationValidator cancellation, ResponseValidator responseValidator, Consumer<QueryPhase> phaseConsumer) throws IOException, KException, CancellationException {
-        if (o == null || i == null) {
+        // capture the streams: a concurrent close() (user disconnect, health-monitor watchdog)
+        // nulls the fields, which must surface as an IOException, never a NullPointerException
+        final OutputStream out = o;
+        final DataInputStream in = i;
+        if (out == null || in == null) {
             throw new IOException("Connection lost");
         }
-        synchronized (o) {
+        synchronized (out) {
             cancellation.checkCancelled();
             phaseConsumer.accept(QueryPhase.ENCODING);
             byte[] buffer = serialize(msgType, x, zip);
 
             cancellation.checkCancelled();
             phaseConsumer.accept(QueryPhase.SENDING);
-            o.write(buffer, 0, buffer.length);
+            out.write(buffer, 0, buffer.length);
         }
 
         phaseConsumer.accept(QueryPhase.WAITING);
-        synchronized (i) {
-            i.readFully(b = new byte[8]); // read the msg header
+        synchronized (in) {
+            in.readFully(b = new byte[8]); // read the msg header
             a = b[0] == 1;  // endianness of the msg
             if (b[1] == 1) { // msg types are 0 - async, 1 - sync, 2 - response
                 sync++;   // an incoming sync message means the remote will expect a response message
@@ -71,12 +75,12 @@ public class KxConnection extends c implements Closeable {
                 cancellation.checkCancelled();
                 responseValidator.checkMessageSize(size);
             } catch (CancellationException ex) {
-                i.skipBytes(readCount);
+                in.skipBytes(readCount);
                 throw ex;
             }
 
             b = Arrays.copyOf(b, size);
-            i.readFully(b, 8, readCount); // read the incoming message in full
+            in.readFully(b, 8, readCount); // read the incoming message in full
 
             cancellation.checkCancelled();
             phaseConsumer.accept(QueryPhase.DECODING);
@@ -124,7 +128,9 @@ public class KxConnection extends c implements Closeable {
             synchronized (in) {
                 watchdogArm.run();
 
-                final byte[] buffer = serialize(1, "::", false);
+                // cs(...): the probe must go out as a char-vector expression (type 10), which the
+                // remote evaluates to identity; a plain Java String would serialise as a symbol atom
+                final byte[] buffer = serialize(1, cs("::"), false);
                 out.write(buffer, 0, buffer.length);
 
                 while (true) {
@@ -162,30 +168,37 @@ public class KxConnection extends c implements Closeable {
     }
 
     @Override
-    public void close() {
-        if (null != s) {
+    public synchronized void close() {
+        // synchronized + null-first: close() is called concurrently (user disconnect, health-monitor
+        // watchdog, dead-connection handling) and an interleaved double close must neither NPE nor
+        // leave streams half-closed. Never takes the o/i stream locks, so it always proceeds even
+        // when a reader is parked - closing the socket is what unblocks that reader.
+        final Socket socket = s;
+        final DataInputStream in = i;
+        final OutputStream out = o;
+        s = null;
+        i = null;
+        o = null;
+        if (socket != null) {
             try {
-                s.close();
-            } catch (IOException ignore) {
+                socket.close();
+            } catch (Exception ignore) {
                 //
             }
-            s = null;
         }
-        if (null != i) {
+        if (in != null) {
             try {
-                i.close();
-            } catch (IOException ignore) {
+                in.close();
+            } catch (Exception ignore) {
                 //
             }
-            i = null;
         }
-        if (null != o) {
+        if (out != null) {
             try {
-                o.close();
-            } catch (IOException ignore) {
+                out.close();
+            } catch (Exception ignore) {
                 //
             }
-            o = null;
         }
     }
 

--- a/src/main/java/kx/KxConnection.java
+++ b/src/main/java/kx/KxConnection.java
@@ -3,12 +3,15 @@ package kx;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.Closeable;
+import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.Socket;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.CancellationException;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 public class KxConnection extends c implements Closeable {
@@ -78,6 +81,71 @@ public class KxConnection extends c implements Closeable {
             cancellation.checkCancelled();
             phaseConsumer.accept(QueryPhase.DECODING);
             return deserialize(b);
+        }
+    }
+
+    /**
+     * Sends a lightweight, side-effect-free sync round-trip ({@code "::"}) to validate that the
+     * connection is alive end-to-end.
+     * <p>
+     * The whole write+read cycle is performed under both the {@code o} and {@code i} locks so it can
+     * never interleave with {@link #query(Object, CancellationValidator, ResponseValidator, Consumer)}:
+     * a user query started while the probe is in flight blocks on the {@code o} lock until the probe
+     * response has been fully consumed.
+     * <p>
+     * {@code abort} is re-checked after the locks are acquired: if a user query has been submitted in
+     * the meantime (its write may already be on the wire), probing now could consume the response
+     * destined for that query, so the probe is skipped. The mutual exclusion on {@code o} guarantees
+     * that a positive "no query in flight" answer inside the lock is authoritative.
+     * <p>
+     * {@code watchdogArm} is invoked right before the probe bytes are written - the caller is expected
+     * to schedule a task that force-closes this connection if the probe does not complete in time,
+     * which unblocks the {@code readFully} below with an IOException on a dead connection.
+     * <p>
+     * Any non-response messages (async pushes, incoming sync requests) received while waiting are
+     * consumed and discarded with the same bookkeeping as {@code query(...)}.
+     *
+     * @param abort       returns true if the probe must be skipped (a user query is in flight)
+     * @param watchdogArm invoked once probing is committed, right before the write
+     * @return true if the probe completed the round-trip; false if it was skipped
+     * @throws IOException if the connection is broken (or was force-closed by the watchdog)
+     * @throws KException  if the remote responded with an error - the connection is alive
+     */
+    public boolean probe(BooleanSupplier abort, Runnable watchdogArm) throws IOException, KException {
+        final OutputStream out = o;
+        final DataInputStream in = i;
+        if (out == null || in == null) {
+            throw new IOException("Connection lost");
+        }
+        synchronized (out) {
+            if (abort.getAsBoolean()) {
+                return false;
+            }
+            synchronized (in) {
+                watchdogArm.run();
+
+                final byte[] buffer = serialize(1, "::", false);
+                out.write(buffer, 0, buffer.length);
+
+                while (true) {
+                    in.readFully(b = new byte[8]); // read the msg header
+                    a = b[0] == 1;  // endianness of the msg
+                    final byte msgType = b[1];
+                    if (msgType == 1) { // an incoming sync message means the remote will expect a response message
+                        sync++;
+                    }
+                    j = 4;
+
+                    final int size = ri();
+                    b = Arrays.copyOf(b, size);
+                    in.readFully(b, 8, size - 8); // read the incoming message in full
+
+                    if (msgType == 2) { // the probe response; anything else is discarded
+                        deserialize(b);
+                        return true;
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/kx/c.java
+++ b/src/main/java/kx/c.java
@@ -1480,7 +1480,14 @@ public class c {
      * @throws UnsupportedEncodingException If the named charset is not supported
      */
     public Object deserialize(byte[] buffer) throws KException, UnsupportedEncodingException {
-        synchronized (i) {
+        // capture the lock: the field may be nulled by a concurrent close(). The buffer is already
+        // fully read at this point, so when the connection is gone decoding proceeds under a
+        // fallback lock instead of dying with a NullPointerException at monitorenter.
+        Object lock = this.i;
+        if (lock == null) {
+            lock = this;
+        }
+        synchronized (lock) {
             b = buffer;
             a = b[0] == 1;  // endianness of the msg
             boolean compressed = b[2] == 1;
@@ -1514,6 +1521,12 @@ public class c {
      */
     public byte[] serialize(int msgType, Object x, boolean zip) throws IOException {
         int length = 8 + nx(x);
+        // capture the lock: the field may be nulled by a concurrent close(), which must surface as
+        // a connection loss, not a NullPointerException at monitorenter
+        final OutputStream o = this.o;
+        if (o == null) {
+            throw new IOException("Connection lost");
+        }
         synchronized (o) {
             B = new byte[length];
             B[0] = 0;

--- a/src/main/java/kx/c.java
+++ b/src/main/java/kx/c.java
@@ -127,6 +127,42 @@ public class c {
         i = new DataInputStream(s.getInputStream());
         o = s.getOutputStream();
         s.setKeepAlive(true);
+        tuneKeepAlive(s);
+    }
+
+    /**
+     * How long (seconds) the connection may stay idle before the first TCP keepalive probe is sent.
+     * OS defaults (2 hours on macOS/Linux) are far above typical gateway idle timeouts, which leaves
+     * orphaned connections undetected; see {@link #tuneKeepAlive(Socket)}.
+     */
+    public static final int TCP_KEEP_IDLE_SEC = 30;
+    /**
+     * Seconds between subsequent keepalive probes when the previous one got no answer.
+     */
+    public static final int TCP_KEEP_INTERVAL_SEC = 10;
+    /**
+     * Number of unanswered probes after which the kernel declares the connection dead and any
+     * blocked read fails with an IOException.
+     */
+    public static final int TCP_KEEP_COUNT = 3;
+
+    /**
+     * Best effort: supported on macOS/Linux since JDK 11; never fail the connection over this.
+     * <p>
+     * {@code setKeepAlive(true)} alone uses OS default timings (first probe after 2 hours on macOS),
+     * so a connection silently orphaned by a network path change (VPN/ZTNA re-assert after sleep)
+     * keeps a read parked forever. With the tuned values a dead connection is declared within
+     * {@code TCP_KEEP_IDLE_SEC + TCP_KEEP_INTERVAL_SEC * TCP_KEEP_COUNT} seconds and the blocked
+     * read fails over to the normal disconnect handling.
+     */
+    private static void tuneKeepAlive(Socket s) {
+        try {
+            s.setOption(jdk.net.ExtendedSocketOptions.TCP_KEEPIDLE, TCP_KEEP_IDLE_SEC);
+            s.setOption(jdk.net.ExtendedSocketOptions.TCP_KEEPINTERVAL, TCP_KEEP_INTERVAL_SEC);
+            s.setOption(jdk.net.ExtendedSocketOptions.TCP_KEEPCOUNT, TCP_KEEP_COUNT);
+        } catch (IOException | RuntimeException e) {
+            System.getLogger("kx.c").log(System.Logger.Level.DEBUG, "TCP keepalive tuning is not supported: " + e);
+        }
     }
 
     /**

--- a/src/main/java/org/kdb/inside/brains/core/ConnectionHealthMonitor.java
+++ b/src/main/java/org/kdb/inside/brains/core/ConnectionHealthMonitor.java
@@ -8,7 +8,9 @@ import kx.c;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Application-level connection health monitoring owned by {@link KdbConnectionManager}:
@@ -30,6 +32,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  * <p>
  * Heartbeats are disabled per connection via the {@code heartbeat} instance option; with the option
  * off no task is ever scheduled for the connection and the code paths are identical to upstream.
+ * <p>
+ * Lifecycle of a monitored entry: created on {@link #connectionOpened}, removed on intentional
+ * disconnect ({@link #connectionClosed} with {@code null} error, {@link #reconnectAborted},
+ * {@link #connectionRemoved}). Auto-reconnect therefore only ever runs for a connection that was
+ * successfully established and has not been manually disconnected since.
  */
 public class ConnectionHealthMonitor implements Disposable {
     private static final Logger log = Logger.getInstance(ConnectionHealthMonitor.class);
@@ -38,14 +45,15 @@ public class ConnectionHealthMonitor implements Disposable {
     static final int MAX_RECONNECT_ATTEMPTS = 20;
 
     private final DeadConnectionHandler deadConnectionHandler;
+    private final ReconnectHandler reconnectHandler;
     private final Executor connectExecutor;
 
     private final Map<InstanceConnection, MonitoredConnection> monitored = new ConcurrentHashMap<>();
 
     /**
-     * Runs heartbeat ticks; a tick blocks for up to the heartbeat timeout when the connection is
-     * dead, so watchdogs run on their own thread ({@link #watchdogScheduler}) and can never be
-     * starved by parked probes.
+     * Runs heartbeat ticks and reconnect timers; a tick blocks for up to the heartbeat timeout when
+     * the connection is dead, so watchdogs run on their own thread ({@link #watchdogScheduler}) and
+     * can never be starved by parked probes.
      */
     private final ScheduledExecutorService heartbeatScheduler;
     private final ScheduledExecutorService watchdogScheduler;
@@ -53,11 +61,15 @@ public class ConnectionHealthMonitor implements Disposable {
     private volatile boolean disposed = false;
 
     /**
-     * @param deadConnectionHandler invoked (from a heartbeat thread) when a probe declared the connection dead
+     * @param deadConnectionHandler invoked (from a heartbeat or watchdog thread) when a probe
+     *                              declared the connection dead; receives the probed KxConnection
+     *                              so a stale death can be recognised and ignored
+     * @param reconnectHandler      performs one reconnect attempt; invoked via {@code connectExecutor}
      * @param connectExecutor       executes reconnect attempts; the production wiring hops to the EDT
      */
-    public ConnectionHealthMonitor(DeadConnectionHandler deadConnectionHandler, Executor connectExecutor) {
+    public ConnectionHealthMonitor(DeadConnectionHandler deadConnectionHandler, ReconnectHandler reconnectHandler, Executor connectExecutor) {
         this.deadConnectionHandler = deadConnectionHandler;
+        this.reconnectHandler = reconnectHandler;
         this.connectExecutor = connectExecutor;
 
         final AtomicInteger counter = new AtomicInteger();
@@ -100,9 +112,13 @@ public class ConnectionHealthMonitor implements Disposable {
     /**
      * A connection has been closed. A {@code null} error means an intentional disconnect and stops
      * all monitoring; an error schedules a reconnect attempt when the option is enabled and the
-     * connection had been successfully established before.
+     * connection had been successfully established before (a monitored entry exists).
      */
     public void connectionClosed(InstanceConnection connection, Exception error, InstanceOptions options) {
+        if (error == null || disposed) { // intentional disconnect - stop and forget
+            connectionRemoved(connection);
+            return;
+        }
         final MonitoredConnection mc = monitored.get(connection);
         if (mc == null) {
             return;
@@ -111,30 +127,29 @@ public class ConnectionHealthMonitor implements Disposable {
             mc.cancelHeartbeat();
             mc.kx = null;
 
-            if (error == null || disposed) { // intentional disconnect - stop everything
-                mc.cancelReconnect();
-                mc.reconnectAttempts.set(0);
-            } else if (options.isSafeAutoReconnect()) {
+            if (options.isSafeAutoReconnect()) {
                 scheduleReconnect(mc);
+            } else {
+                mc.cancelReconnect();
             }
         }
     }
 
     /**
-     * The user asked for a disconnect: cancels pending reconnect attempts even if the connection is
-     * already in the DISCONNECTED state (waiting for the next retry).
+     * The user asked for a disconnect: stops monitoring entirely, aborting pending reconnect
+     * attempts even if the connection is already in the DISCONNECTED state (waiting for the next
+     * retry) or a retry task is mid-flight (the generation bump invalidates it).
      */
     public void reconnectAborted(InstanceConnection connection) {
-        final MonitoredConnection mc = monitored.get(connection);
-        if (mc == null) {
-            return;
-        }
-        synchronized (mc) {
-            if (mc.reconnectTask != null) {
-                log.info("Auto-reconnect of " + connection.getName() + " cancelled by manual disconnect");
+        final MonitoredConnection mc = monitored.remove(connection);
+        if (mc != null) {
+            synchronized (mc) {
+                if (mc.reconnectTask != null) {
+                    log.info("Auto-reconnect of " + connection.getName() + " cancelled by manual disconnect");
+                }
+                mc.cancelHeartbeat();
+                mc.cancelReconnect();
             }
-            mc.cancelReconnect();
-            mc.reconnectAttempts.set(0);
         }
     }
 
@@ -186,17 +201,28 @@ public class ConnectionHealthMonitor implements Disposable {
         }
 
         final long timeoutMs = mc.options.getSafeHeartbeatTimeoutMs();
+        // Death is claimed exactly once, by whoever detects it first: the watchdog (probe exceeded
+        // its deadline - even if the response then arrives, the socket is already being closed) or
+        // the probe failure path below. ScheduledFuture.cancel() alone cannot arbitrate this: it may
+        // report success while the task body is already running.
+        final AtomicBoolean deathClaimed = new AtomicBoolean();
         // Armed inside probe(...) right before the write, when the probe is committed: an armed
         // watchdog can therefore never kill a connection whose probe was skipped over a user query.
-        final CompletableFuture<ScheduledFuture<?>> watchdog = new CompletableFuture<>();
+        final AtomicReference<ScheduledFuture<?>> watchdog = new AtomicReference<>();
         try {
             final boolean probed = kx.probe(
                     () -> connection.getQuery() != null,
-                    () -> watchdog.complete(watchdogScheduler.schedule(() -> {
-                        log.warn("Heartbeat probe of " + connection.getName() + " got no response in " + timeoutMs + "ms - force-closing the socket");
-                        kx.close();
+                    () -> watchdog.set(watchdogScheduler.schedule(() -> {
+                        if (deathClaimed.compareAndSet(false, true)) {
+                            final String reason = "Heartbeat probe got no response in " + timeoutMs + "ms";
+                            log.warn(reason + " - force-closing the socket of " + connection.getName());
+                            kx.close();
+                            deadConnectionHandler.connectionDead(connection, kx, new IOException(reason));
+                        }
                     }, timeoutMs, TimeUnit.MILLISECONDS)));
             cancelWatchdog(watchdog);
+            // if the watchdog claimed the death concurrently (response arrived at ~the deadline), it
+            // has already closed the socket and reported the death - nothing more to do here
             if (probed) {
                 log.debug("Heartbeat probe ok: " + connection.getName());
             } else {
@@ -207,28 +233,29 @@ public class ConnectionHealthMonitor implements Disposable {
             cancelWatchdog(watchdog);
             log.debug("Heartbeat probe of " + connection.getName() + " got error response: " + ex.getMessage());
         } catch (Throwable ex) {
-            final boolean stalled = !cancelWatchdog(watchdog);
-            final String reason = stalled ?
-                    "Heartbeat probe got no response in " + timeoutMs + "ms" :
-                    "Heartbeat probe failed: " + ex.getMessage();
-            log.warn(reason + " - closing connection " + connection.getName(), ex);
-            deadConnectionHandler.connectionDead(connection, new IOException(reason, ex));
+            cancelWatchdog(watchdog);
+            if (deathClaimed.compareAndSet(false, true)) {
+                final String reason = "Heartbeat probe failed: " + ex.getMessage();
+                log.warn(reason + " - closing connection " + connection.getName(), ex);
+                deadConnectionHandler.connectionDead(connection, kx, new IOException(reason, ex));
+            }
+            // else: the watchdog claimed the death and closed the socket; this exception is the
+            // consequence of that close and has already been handled
+        }
+    }
+
+    private static void cancelWatchdog(AtomicReference<ScheduledFuture<?>> watchdog) {
+        final ScheduledFuture<?> task = watchdog.get();
+        if (task != null) {
+            task.cancel(false);
         }
     }
 
     /**
-     * @return false if the watchdog was armed and already fired (the probe timed out)
+     * Caller must hold the {@code mc} lock. The scheduled task and its EDT hop both re-validate the
+     * reconnect generation, so {@link MonitoredConnection#cancelReconnect()} (which bumps it)
+     * reliably aborts a retry even when the task has already left the scheduler queue.
      */
-    private static boolean cancelWatchdog(CompletableFuture<ScheduledFuture<?>> watchdog) {
-        if (!watchdog.complete(null)) { // was armed
-            final ScheduledFuture<?> task = watchdog.getNow(null);
-            if (task != null) {
-                return task.cancel(false) || !task.isDone();
-            }
-        }
-        return true;
-    }
-
     private void scheduleReconnect(MonitoredConnection mc) {
         final int attempt = mc.reconnectAttempts.getAndIncrement();
         if (attempt >= MAX_RECONNECT_ATTEMPTS) {
@@ -239,23 +266,46 @@ public class ConnectionHealthMonitor implements Disposable {
         log.info("Auto-reconnect attempt " + (attempt + 1) + "/" + MAX_RECONNECT_ATTEMPTS + " of " + mc.connection.getName() + " in " + delay + "s");
 
         mc.cancelReconnect();
+        final int generation = mc.reconnectGeneration;
         mc.reconnectTask = heartbeatScheduler.schedule(() -> {
             synchronized (mc) {
+                if (generation != mc.reconnectGeneration) {
+                    return; // aborted/superseded while queued
+                }
                 mc.reconnectTask = null;
             }
-            if (!disposed && monitored.containsKey(mc.connection) && mc.connection.getState() == InstanceState.DISCONNECTED) {
-                connectExecutor.execute(mc.connection::connect);
+            if (disposed || !monitored.containsKey(mc.connection)) {
+                return;
             }
+            connectExecutor.execute(() -> {
+                synchronized (mc) {
+                    if (generation != mc.reconnectGeneration) {
+                        return; // aborted between the timer firing and the EDT hop
+                    }
+                }
+                if (!disposed && monitored.containsKey(mc.connection) && mc.connection.getState() == InstanceState.DISCONNECTED) {
+                    reconnectHandler.reconnect(mc.connection);
+                }
+            });
         }, delay, TimeUnit.SECONDS);
     }
 
     /**
      * Invoked when a heartbeat declared a connection dead; the implementation is expected to close
-     * the connection with the given reason through the usual state/listener mechanism.
+     * the connection with the given reason through the usual state/listener mechanism, ignoring the
+     * report when {@code kx} is no longer the connection's current transport (a stale probe).
      */
     @FunctionalInterface
     public interface DeadConnectionHandler {
-        void connectionDead(InstanceConnection connection, IOException reason);
+        void connectionDead(InstanceConnection connection, KxConnection kx, IOException reason);
+    }
+
+    /**
+     * Performs one reconnect attempt for a connection that died with an error.
+     */
+    @FunctionalInterface
+    public interface ReconnectHandler {
+        void reconnect(InstanceConnection connection);
     }
 
     private static class MonitoredConnection {
@@ -267,6 +317,9 @@ public class ConnectionHealthMonitor implements Disposable {
 
         ScheduledFuture<?> heartbeatTask;
         ScheduledFuture<?> reconnectTask;
+        // bumped on every cancel: a retry task (even one already running) aborts when its captured
+        // generation no longer matches. Guarded by the mc lock.
+        int reconnectGeneration;
 
         MonitoredConnection(InstanceConnection connection) {
             this.connection = connection;
@@ -280,6 +333,7 @@ public class ConnectionHealthMonitor implements Disposable {
         }
 
         void cancelReconnect() {
+            reconnectGeneration++;
             if (reconnectTask != null) {
                 reconnectTask.cancel(false);
                 reconnectTask = null;

--- a/src/main/java/org/kdb/inside/brains/core/ConnectionHealthMonitor.java
+++ b/src/main/java/org/kdb/inside/brains/core/ConnectionHealthMonitor.java
@@ -1,0 +1,289 @@
+package org.kdb.inside.brains.core;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.diagnostic.Logger;
+import kx.KxConnection;
+import kx.c;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Application-level connection health monitoring owned by {@link KdbConnectionManager}:
+ * <ul>
+ * <li><b>Heartbeat + watchdog:</b> while a connection is idle (no user query in flight), a
+ * side-effect-free sync probe ({@code "::"}) is sent periodically. A watchdog force-closes the
+ * socket if the probe does not complete within the configured timeout, which unblocks the parked
+ * read with an IOException and flows into the normal disconnect handling. This catches connections
+ * silently orphaned by network path changes (VPN/ZTNA re-assert after sleep/wake) that the remote
+ * never terminates with FIN/RST.</li>
+ * <li><b>Auto-reconnect:</b> when a previously established connection dies with an error (heartbeat-,
+ * keepalive- or IOException-detected) and the {@code autoReconnect} option is enabled, reconnection
+ * is retried with backoff until it succeeds, the attempts cap is reached, the instance is removed,
+ * or the user disconnects manually.</li>
+ * </ul>
+ * Asynchronous connections ({@code async} option) are never actively probed: a sync probe response
+ * could be mistaken for the reply a pending async round-trip is waiting for. They still benefit from
+ * the tuned TCP keepalive in {@code kx.c#io(Socket)}.
+ * <p>
+ * Heartbeats are disabled per connection via the {@code heartbeat} instance option; with the option
+ * off no task is ever scheduled for the connection and the code paths are identical to upstream.
+ */
+public class ConnectionHealthMonitor implements Disposable {
+    private static final Logger log = Logger.getInstance(ConnectionHealthMonitor.class);
+
+    static final int[] RECONNECT_DELAYS_SEC = {2, 5, 10, 30};
+    static final int MAX_RECONNECT_ATTEMPTS = 20;
+
+    private final DeadConnectionHandler deadConnectionHandler;
+    private final Executor connectExecutor;
+
+    private final Map<InstanceConnection, MonitoredConnection> monitored = new ConcurrentHashMap<>();
+
+    /**
+     * Runs heartbeat ticks; a tick blocks for up to the heartbeat timeout when the connection is
+     * dead, so watchdogs run on their own thread ({@link #watchdogScheduler}) and can never be
+     * starved by parked probes.
+     */
+    private final ScheduledExecutorService heartbeatScheduler;
+    private final ScheduledExecutorService watchdogScheduler;
+
+    private volatile boolean disposed = false;
+
+    /**
+     * @param deadConnectionHandler invoked (from a heartbeat thread) when a probe declared the connection dead
+     * @param connectExecutor       executes reconnect attempts; the production wiring hops to the EDT
+     */
+    public ConnectionHealthMonitor(DeadConnectionHandler deadConnectionHandler, Executor connectExecutor) {
+        this.deadConnectionHandler = deadConnectionHandler;
+        this.connectExecutor = connectExecutor;
+
+        final AtomicInteger counter = new AtomicInteger();
+        heartbeatScheduler = Executors.newScheduledThreadPool(2, r -> {
+            final Thread t = new Thread(r, "kdb-heartbeat-" + counter.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        });
+        watchdogScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            final Thread t = new Thread(r, "kdb-heartbeat-watchdog");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    /**
+     * A connection has been (re-)established. Resets any reconnect bookkeeping and starts the
+     * heartbeat when enabled for a synchronous connection.
+     */
+    public void connectionOpened(InstanceConnection connection, KxConnection kx, InstanceOptions options) {
+        if (disposed) {
+            return;
+        }
+        final MonitoredConnection mc = monitored.computeIfAbsent(connection, MonitoredConnection::new);
+        synchronized (mc) {
+            mc.cancelHeartbeat();
+            mc.cancelReconnect();
+            mc.reconnectAttempts.set(0);
+            mc.kx = kx;
+            mc.options = options;
+
+            if (options.isSafeHeartbeatEnabled() && !options.isSafeAsync()) {
+                final int interval = options.getSafeHeartbeatIntervalSec();
+                mc.heartbeatTask = heartbeatScheduler.scheduleWithFixedDelay(() -> heartbeat(mc), interval, interval, TimeUnit.SECONDS);
+                log.debug("Heartbeat started for " + connection.getName() + ": interval " + interval + "s, timeout " + options.getSafeHeartbeatTimeoutMs() + "ms");
+            }
+        }
+    }
+
+    /**
+     * A connection has been closed. A {@code null} error means an intentional disconnect and stops
+     * all monitoring; an error schedules a reconnect attempt when the option is enabled and the
+     * connection had been successfully established before.
+     */
+    public void connectionClosed(InstanceConnection connection, Exception error, InstanceOptions options) {
+        final MonitoredConnection mc = monitored.get(connection);
+        if (mc == null) {
+            return;
+        }
+        synchronized (mc) {
+            mc.cancelHeartbeat();
+            mc.kx = null;
+
+            if (error == null || disposed) { // intentional disconnect - stop everything
+                mc.cancelReconnect();
+                mc.reconnectAttempts.set(0);
+            } else if (options.isSafeAutoReconnect()) {
+                scheduleReconnect(mc);
+            }
+        }
+    }
+
+    /**
+     * The user asked for a disconnect: cancels pending reconnect attempts even if the connection is
+     * already in the DISCONNECTED state (waiting for the next retry).
+     */
+    public void reconnectAborted(InstanceConnection connection) {
+        final MonitoredConnection mc = monitored.get(connection);
+        if (mc == null) {
+            return;
+        }
+        synchronized (mc) {
+            if (mc.reconnectTask != null) {
+                log.info("Auto-reconnect of " + connection.getName() + " cancelled by manual disconnect");
+            }
+            mc.cancelReconnect();
+            mc.reconnectAttempts.set(0);
+        }
+    }
+
+    /**
+     * The instance has been removed: stop and forget everything about it.
+     */
+    public void connectionRemoved(InstanceConnection connection) {
+        final MonitoredConnection mc = monitored.remove(connection);
+        if (mc != null) {
+            synchronized (mc) {
+                mc.cancelHeartbeat();
+                mc.cancelReconnect();
+                mc.kx = null;
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        disposed = true;
+        heartbeatScheduler.shutdownNow();
+        watchdogScheduler.shutdownNow();
+        monitored.clear();
+    }
+
+    /**
+     * Test hook: runs one heartbeat tick synchronously.
+     *
+     * @return false if the connection is not monitored
+     */
+    boolean runHeartbeatNow(InstanceConnection connection) {
+        final MonitoredConnection mc = monitored.get(connection);
+        if (mc == null) {
+            return false;
+        }
+        heartbeat(mc);
+        return true;
+    }
+
+    private void heartbeat(MonitoredConnection mc) {
+        final InstanceConnection connection = mc.connection;
+        final KxConnection kx = mc.kx;
+        if (disposed || kx == null || !kx.isConnected() || connection.getState() != InstanceState.CONNECTED) {
+            return;
+        }
+        if (connection.getQuery() != null) { // user query in flight - skip this tick
+            log.debug("Heartbeat tick skipped, query in flight: " + connection.getName());
+            return;
+        }
+
+        final long timeoutMs = mc.options.getSafeHeartbeatTimeoutMs();
+        // Armed inside probe(...) right before the write, when the probe is committed: an armed
+        // watchdog can therefore never kill a connection whose probe was skipped over a user query.
+        final CompletableFuture<ScheduledFuture<?>> watchdog = new CompletableFuture<>();
+        try {
+            final boolean probed = kx.probe(
+                    () -> connection.getQuery() != null,
+                    () -> watchdog.complete(watchdogScheduler.schedule(() -> {
+                        log.warn("Heartbeat probe of " + connection.getName() + " got no response in " + timeoutMs + "ms - force-closing the socket");
+                        kx.close();
+                    }, timeoutMs, TimeUnit.MILLISECONDS)));
+            cancelWatchdog(watchdog);
+            if (probed) {
+                log.debug("Heartbeat probe ok: " + connection.getName());
+            } else {
+                log.debug("Heartbeat probe skipped, query in flight: " + connection.getName());
+            }
+        } catch (c.KException ex) {
+            // the remote evaluated the probe and responded, even if with an error - the path is alive
+            cancelWatchdog(watchdog);
+            log.debug("Heartbeat probe of " + connection.getName() + " got error response: " + ex.getMessage());
+        } catch (Throwable ex) {
+            final boolean stalled = !cancelWatchdog(watchdog);
+            final String reason = stalled ?
+                    "Heartbeat probe got no response in " + timeoutMs + "ms" :
+                    "Heartbeat probe failed: " + ex.getMessage();
+            log.warn(reason + " - closing connection " + connection.getName(), ex);
+            deadConnectionHandler.connectionDead(connection, new IOException(reason, ex));
+        }
+    }
+
+    /**
+     * @return false if the watchdog was armed and already fired (the probe timed out)
+     */
+    private static boolean cancelWatchdog(CompletableFuture<ScheduledFuture<?>> watchdog) {
+        if (!watchdog.complete(null)) { // was armed
+            final ScheduledFuture<?> task = watchdog.getNow(null);
+            if (task != null) {
+                return task.cancel(false) || !task.isDone();
+            }
+        }
+        return true;
+    }
+
+    private void scheduleReconnect(MonitoredConnection mc) {
+        final int attempt = mc.reconnectAttempts.getAndIncrement();
+        if (attempt >= MAX_RECONNECT_ATTEMPTS) {
+            log.warn("Auto-reconnect of " + mc.connection.getName() + " gave up after " + MAX_RECONNECT_ATTEMPTS + " failed attempts");
+            return;
+        }
+        final int delay = RECONNECT_DELAYS_SEC[Math.min(attempt, RECONNECT_DELAYS_SEC.length - 1)];
+        log.info("Auto-reconnect attempt " + (attempt + 1) + "/" + MAX_RECONNECT_ATTEMPTS + " of " + mc.connection.getName() + " in " + delay + "s");
+
+        mc.cancelReconnect();
+        mc.reconnectTask = heartbeatScheduler.schedule(() -> {
+            synchronized (mc) {
+                mc.reconnectTask = null;
+            }
+            if (!disposed && monitored.containsKey(mc.connection) && mc.connection.getState() == InstanceState.DISCONNECTED) {
+                connectExecutor.execute(mc.connection::connect);
+            }
+        }, delay, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Invoked when a heartbeat declared a connection dead; the implementation is expected to close
+     * the connection with the given reason through the usual state/listener mechanism.
+     */
+    @FunctionalInterface
+    public interface DeadConnectionHandler {
+        void connectionDead(InstanceConnection connection, IOException reason);
+    }
+
+    private static class MonitoredConnection {
+        final InstanceConnection connection;
+        final AtomicInteger reconnectAttempts = new AtomicInteger();
+
+        volatile KxConnection kx;
+        volatile InstanceOptions options;
+
+        ScheduledFuture<?> heartbeatTask;
+        ScheduledFuture<?> reconnectTask;
+
+        MonitoredConnection(InstanceConnection connection) {
+            this.connection = connection;
+        }
+
+        void cancelHeartbeat() {
+            if (heartbeatTask != null) {
+                heartbeatTask.cancel(false);
+                heartbeatTask = null;
+            }
+        }
+
+        void cancelReconnect() {
+            if (reconnectTask != null) {
+                reconnectTask.cancel(false);
+                reconnectTask = null;
+            }
+        }
+    }
+}

--- a/src/main/java/org/kdb/inside/brains/core/InstanceOptions.java
+++ b/src/main/java/org/kdb/inside/brains/core/InstanceOptions.java
@@ -134,14 +134,16 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
                 b.heartbeat(Boolean.valueOf(heartbeat));
             }
 
+            // out-of-range values are clamped, not rejected: one bad heartbeat number in a
+            // hand-edited or older file must not silently discard all the other options
             final String heartbeatInterval = el.getAttributeValue("heartbeatInterval");
             if (heartbeatInterval != null) {
-                b.heartbeatInterval(Integer.decode(heartbeatInterval.trim()));
+                b.heartbeatInterval(Math.max(MIN_HEARTBEAT_INTERVAL_SEC, Integer.decode(heartbeatInterval.trim())));
             }
 
             final String heartbeatTimeout = el.getAttributeValue("heartbeatTimeout");
             if (heartbeatTimeout != null) {
-                b.heartbeatTimeout(Integer.decode(heartbeatTimeout.trim()));
+                b.heartbeatTimeout(Math.max(MIN_HEARTBEAT_TIMEOUT_MS, Integer.decode(heartbeatTimeout.trim())));
             }
 
             final String autoReconnect = el.getAttributeValue("autoReconnect");
@@ -283,6 +285,42 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
     @Transient
     public boolean isSafeAutoReconnect() {
         return hasAutoReconnect() ? autoReconnect : DEFAULT_AUTO_RECONNECT;
+    }
+
+    /**
+     * Fills every absent (null) option with its default. The application-level options are the root
+     * of the scope/instance inheritance chain and must stay fully populated: a configuration written
+     * by an older plugin version lacks the newer attributes and would otherwise resurface as null
+     * after XML deserialization.
+     */
+    public void fillAbsentWithDefaults() {
+        if (tls == null) {
+            tls = DEFAULT_TLS;
+        }
+        if (zip == null) {
+            zip = DEFAULT_ZIP;
+        }
+        if (async == null) {
+            async = DEFAULT_ASYNC;
+        }
+        if (timeout == null) {
+            timeout = DEFAULT_TIMEOUT;
+        }
+        if (encoding == null) {
+            encoding = DEFAULT_ENCODING;
+        }
+        if (heartbeat == null) {
+            heartbeat = DEFAULT_HEARTBEAT;
+        }
+        if (heartbeatInterval == null) {
+            heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL_SEC;
+        }
+        if (heartbeatTimeout == null) {
+            heartbeatTimeout = DEFAULT_HEARTBEAT_TIMEOUT_MS;
+        }
+        if (autoReconnect == null) {
+            autoReconnect = DEFAULT_AUTO_RECONNECT;
+        }
     }
 
     @Override

--- a/src/main/java/org/kdb/inside/brains/core/InstanceOptions.java
+++ b/src/main/java/org/kdb/inside/brains/core/InstanceOptions.java
@@ -20,12 +20,27 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
     private Boolean async;
     @Attribute
     private Integer timeout;
+    @Attribute
+    private Boolean heartbeat;
+    @Attribute
+    private Integer heartbeatInterval;
+    @Attribute
+    private Integer heartbeatTimeout;
+    @Attribute
+    private Boolean autoReconnect;
 
     public static final int DEFAULT_TIMEOUT = 1000;
     public static final boolean DEFAULT_TLS = false;
     public static final boolean DEFAULT_ZIP = false;
     public static final boolean DEFAULT_ASYNC = false;
     public static final String DEFAULT_ENCODING = "UTF-8";
+    public static final boolean DEFAULT_HEARTBEAT = true;
+    public static final int DEFAULT_HEARTBEAT_INTERVAL_SEC = 30;
+    public static final int DEFAULT_HEARTBEAT_TIMEOUT_MS = 5000;
+    public static final boolean DEFAULT_AUTO_RECONNECT = false;
+
+    public static final int MIN_HEARTBEAT_INTERVAL_SEC = 5;
+    public static final int MIN_HEARTBEAT_TIMEOUT_MS = 500;
 
     public static final InstanceOptions INHERITED = new InstanceOptions();
 
@@ -35,16 +50,20 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
     public InstanceOptions() {
     }
 
-    private InstanceOptions(Boolean tls, Boolean zip, Boolean async, Integer timeout, String encoding) {
+    private InstanceOptions(Boolean tls, Boolean zip, Boolean async, Integer timeout, String encoding, Boolean heartbeat, Integer heartbeatInterval, Integer heartbeatTimeout, Boolean autoReconnect) {
         this.tls = tls;
         this.zip = zip;
         this.async = async;
         this.timeout = timeout;
         this.encoding = encoding;
+        this.heartbeat = heartbeat;
+        this.heartbeatInterval = heartbeatInterval;
+        this.heartbeatTimeout = heartbeatTimeout;
+        this.autoReconnect = autoReconnect;
     }
 
     public static InstanceOptions defaultOptions() {
-        return new InstanceOptions(DEFAULT_TLS, DEFAULT_ZIP, DEFAULT_ASYNC, DEFAULT_TIMEOUT, DEFAULT_ENCODING);
+        return new InstanceOptions(DEFAULT_TLS, DEFAULT_ZIP, DEFAULT_ASYNC, DEFAULT_TIMEOUT, DEFAULT_ENCODING, DEFAULT_HEARTBEAT, DEFAULT_HEARTBEAT_INTERVAL_SEC, DEFAULT_HEARTBEAT_TIMEOUT_MS, DEFAULT_AUTO_RECONNECT);
     }
 
     public static InstanceOptions fromParameters(String params) {
@@ -110,6 +129,26 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
                 b.encoding(encoding);
             }
 
+            final String heartbeat = el.getAttributeValue("heartbeat");
+            if (heartbeat != null) {
+                b.heartbeat(Boolean.valueOf(heartbeat));
+            }
+
+            final String heartbeatInterval = el.getAttributeValue("heartbeatInterval");
+            if (heartbeatInterval != null) {
+                b.heartbeatInterval(Integer.decode(heartbeatInterval.trim()));
+            }
+
+            final String heartbeatTimeout = el.getAttributeValue("heartbeatTimeout");
+            if (heartbeatTimeout != null) {
+                b.heartbeatTimeout(Integer.decode(heartbeatTimeout.trim()));
+            }
+
+            final String autoReconnect = el.getAttributeValue("autoReconnect");
+            if (autoReconnect != null) {
+                b.autoReconnect(Boolean.valueOf(autoReconnect));
+            }
+
             return b.create();
         } catch (Exception ignore) {
             return INHERITED;
@@ -131,6 +170,10 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
                 .async(resolve(options, o -> o.async))
                 .timeout(resolve(options, o -> o.timeout))
                 .encoding(resolve(options, o -> o.encoding))
+                .heartbeat(resolve(options, o -> o.heartbeat))
+                .heartbeatInterval(resolve(options, o -> o.heartbeatInterval))
+                .heartbeatTimeout(resolve(options, o -> o.heartbeatTimeout))
+                .autoReconnect(resolve(options, o -> o.autoReconnect))
                 .safe()
                 .create();
     }
@@ -202,6 +245,46 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
         return hasEncoding() ? encoding : DEFAULT_ENCODING;
     }
 
+    @Transient
+    public boolean hasHeartbeat() {
+        return heartbeat != null;
+    }
+
+    @Transient
+    public boolean isSafeHeartbeatEnabled() {
+        return hasHeartbeat() ? heartbeat : DEFAULT_HEARTBEAT;
+    }
+
+    @Transient
+    public boolean hasHeartbeatInterval() {
+        return heartbeatInterval != null;
+    }
+
+    @Transient
+    public int getSafeHeartbeatIntervalSec() {
+        return hasHeartbeatInterval() ? heartbeatInterval : DEFAULT_HEARTBEAT_INTERVAL_SEC;
+    }
+
+    @Transient
+    public boolean hasHeartbeatTimeout() {
+        return heartbeatTimeout != null;
+    }
+
+    @Transient
+    public int getSafeHeartbeatTimeoutMs() {
+        return hasHeartbeatTimeout() ? heartbeatTimeout : DEFAULT_HEARTBEAT_TIMEOUT_MS;
+    }
+
+    @Transient
+    public boolean hasAutoReconnect() {
+        return autoReconnect != null;
+    }
+
+    @Transient
+    public boolean isSafeAutoReconnect() {
+        return hasAutoReconnect() ? autoReconnect : DEFAULT_AUTO_RECONNECT;
+    }
+
     @Override
     public void copyFrom(InstanceOptions options) {
         this.tls = options.tls;
@@ -209,18 +292,23 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
         this.async = options.async;
         this.timeout = options.timeout;
         this.encoding = options.encoding;
+        this.heartbeat = options.heartbeat;
+        this.heartbeatInterval = options.heartbeatInterval;
+        this.heartbeatTimeout = options.heartbeatTimeout;
+        this.autoReconnect = options.autoReconnect;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof InstanceOptions that)) return false;
-        return Objects.equals(tls, that.tls) && Objects.equals(zip, that.zip) && Objects.equals(async, that.async) && Objects.equals(timeout, that.timeout) && Objects.equals(encoding, that.encoding);
+        return Objects.equals(tls, that.tls) && Objects.equals(zip, that.zip) && Objects.equals(async, that.async) && Objects.equals(timeout, that.timeout) && Objects.equals(encoding, that.encoding)
+                && Objects.equals(heartbeat, that.heartbeat) && Objects.equals(heartbeatInterval, that.heartbeatInterval) && Objects.equals(heartbeatTimeout, that.heartbeatTimeout) && Objects.equals(autoReconnect, that.autoReconnect);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tls, zip, async, timeout, encoding);
+        return Objects.hash(tls, zip, async, timeout, encoding, heartbeat, heartbeatInterval, heartbeatTimeout, autoReconnect);
     }
 
     @Override
@@ -231,11 +319,15 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
                 ", async=" + async +
                 ", timeout=" + timeout +
                 ", encoding=" + encoding +
+                ", heartbeat=" + heartbeat +
+                ", heartbeatInterval=" + heartbeatInterval +
+                ", heartbeatTimeout=" + heartbeatTimeout +
+                ", autoReconnect=" + autoReconnect +
                 '}';
     }
 
     public String toParameters() {
-        final List<String> b = new ArrayList<>(5);
+        final List<String> b = new ArrayList<>(9);
         if (hasTls()) {
             b.add("tls=" + tls);
         }
@@ -250,6 +342,18 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
         }
         if (hasEncoding()) {
             b.add("encoding=" + encoding);
+        }
+        if (hasHeartbeat()) {
+            b.add("heartbeat=" + heartbeat);
+        }
+        if (hasHeartbeatInterval()) {
+            b.add("heartbeatInterval=" + heartbeatInterval);
+        }
+        if (hasHeartbeatTimeout()) {
+            b.add("heartbeatTimeout=" + heartbeatTimeout);
+        }
+        if (hasAutoReconnect()) {
+            b.add("autoReconnect=" + autoReconnect);
         }
         return String.join("&", b);
     }
@@ -270,6 +374,18 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
         if (encoding != null) {
             el.setAttribute("encoding", encoding);
         }
+        if (heartbeat != null) {
+            el.setAttribute("heartbeat", String.valueOf(heartbeat));
+        }
+        if (heartbeatInterval != null) {
+            el.setAttribute("heartbeatInterval", String.valueOf(heartbeatInterval));
+        }
+        if (heartbeatTimeout != null) {
+            el.setAttribute("heartbeatTimeout", String.valueOf(heartbeatTimeout));
+        }
+        if (autoReconnect != null) {
+            el.setAttribute("autoReconnect", String.valueOf(autoReconnect));
+        }
     }
 
     public static class Builder {
@@ -278,6 +394,10 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
         private Boolean async;
         private Integer timeout;
         private String encoding;
+        private Boolean heartbeat;
+        private Integer heartbeatInterval;
+        private Integer heartbeatTimeout;
+        private Boolean autoReconnect;
 
         public Builder tls(Boolean tls) {
             this.tls = tls;
@@ -307,6 +427,32 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
             return this;
         }
 
+        public Builder heartbeat(Boolean heartbeat) {
+            this.heartbeat = heartbeat;
+            return this;
+        }
+
+        public Builder heartbeatInterval(Integer heartbeatInterval) {
+            if (heartbeatInterval != null && heartbeatInterval < MIN_HEARTBEAT_INTERVAL_SEC) {
+                throw new IllegalArgumentException("Heartbeat interval can't be less than " + MIN_HEARTBEAT_INTERVAL_SEC);
+            }
+            this.heartbeatInterval = heartbeatInterval;
+            return this;
+        }
+
+        public Builder heartbeatTimeout(Integer heartbeatTimeout) {
+            if (heartbeatTimeout != null && heartbeatTimeout < MIN_HEARTBEAT_TIMEOUT_MS) {
+                throw new IllegalArgumentException("Heartbeat timeout can't be less than " + MIN_HEARTBEAT_TIMEOUT_MS);
+            }
+            this.heartbeatTimeout = heartbeatTimeout;
+            return this;
+        }
+
+        public Builder autoReconnect(Boolean autoReconnect) {
+            this.autoReconnect = autoReconnect;
+            return this;
+        }
+
         public Builder safe() {
             if (tls == null) {
                 tls = DEFAULT_TLS;
@@ -323,11 +469,23 @@ public final class InstanceOptions implements SettingsBean<InstanceOptions> {
             if (encoding == null) {
                 encoding = DEFAULT_ENCODING;
             }
+            if (heartbeat == null) {
+                heartbeat = DEFAULT_HEARTBEAT;
+            }
+            if (heartbeatInterval == null) {
+                heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL_SEC;
+            }
+            if (heartbeatTimeout == null) {
+                heartbeatTimeout = DEFAULT_HEARTBEAT_TIMEOUT_MS;
+            }
+            if (autoReconnect == null) {
+                autoReconnect = DEFAULT_AUTO_RECONNECT;
+            }
             return this;
         }
 
         public InstanceOptions create() {
-            return new InstanceOptions(tls, zip, async, timeout, encoding);
+            return new InstanceOptions(tls, zip, async, timeout, encoding, heartbeat, heartbeatInterval, heartbeatTimeout, autoReconnect);
         }
     }
 }

--- a/src/main/java/org/kdb/inside/brains/core/InstanceOptionsPanel.java
+++ b/src/main/java/org/kdb/inside/brains/core/InstanceOptionsPanel.java
@@ -35,6 +35,20 @@ public class InstanceOptionsPanel extends JPanel {
     private final JBIntSpinner timeoutSpinner = new JBIntSpinner(1000, 1000, Integer.MAX_VALUE, 10);
     private final JBCheckBox timeoutSpinnerOverride = new JBCheckBox();
 
+    private final JBCheckBox heartbeatCheckbox = new JBCheckBox("Health check is enabled");
+    private final JBCheckBox heartbeatCheckboxOverride = new JBCheckBox();
+
+    private final JBLabel heartbeatIntervalLabel = new JBLabel("Health-check interval, s: ");
+    private final JBIntSpinner heartbeatIntervalSpinner = new JBIntSpinner(InstanceOptions.DEFAULT_HEARTBEAT_INTERVAL_SEC, InstanceOptions.MIN_HEARTBEAT_INTERVAL_SEC, Integer.MAX_VALUE, 5);
+    private final JBCheckBox heartbeatIntervalOverride = new JBCheckBox();
+
+    private final JBLabel heartbeatTimeoutLabel = new JBLabel("Health-check timeout, ms: ");
+    private final JBIntSpinner heartbeatTimeoutSpinner = new JBIntSpinner(InstanceOptions.DEFAULT_HEARTBEAT_TIMEOUT_MS, InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS, Integer.MAX_VALUE, 100);
+    private final JBCheckBox heartbeatTimeoutOverride = new JBCheckBox();
+
+    private final JBCheckBox autoReconnectCheckbox = new JBCheckBox("Reconnect automatically");
+    private final JBCheckBox autoReconnectCheckboxOverride = new JBCheckBox();
+
     private final boolean inherited;
     private final InstanceOptions parentOptions;
 
@@ -95,20 +109,56 @@ public class InstanceOptionsPanel extends JPanel {
         });
         final JPanel encodingPanel = createLabeledPanel(encodingLabel, encodingCombobox);
 
+        heartbeatCheckbox.addItemListener(e -> notifyOptionsChanged());
+        heartbeatCheckboxOverride.addItemListener(e -> {
+            heartbeatCheckbox.setEnabled(heartbeatCheckboxOverride.isSelected());
+            notifyOptionsChanged();
+        });
+
+        heartbeatIntervalSpinner.addChangeListener(e -> notifyOptionsChanged());
+        heartbeatIntervalOverride.addChangeListener(e -> {
+            heartbeatIntervalLabel.setEnabled(heartbeatIntervalOverride.isSelected());
+            heartbeatIntervalSpinner.setEnabled(heartbeatIntervalOverride.isSelected());
+            notifyOptionsChanged();
+        });
+        final JPanel heartbeatIntervalPanel = createLabeledPanel(heartbeatIntervalLabel, heartbeatIntervalSpinner);
+
+        heartbeatTimeoutSpinner.addChangeListener(e -> notifyOptionsChanged());
+        heartbeatTimeoutOverride.addChangeListener(e -> {
+            heartbeatTimeoutLabel.setEnabled(heartbeatTimeoutOverride.isSelected());
+            heartbeatTimeoutSpinner.setEnabled(heartbeatTimeoutOverride.isSelected());
+            notifyOptionsChanged();
+        });
+        final JPanel heartbeatTimeoutPanel = createLabeledPanel(heartbeatTimeoutLabel, heartbeatTimeoutSpinner);
+
+        autoReconnectCheckbox.addItemListener(e -> notifyOptionsChanged());
+        autoReconnectCheckboxOverride.addItemListener(e -> {
+            autoReconnectCheckbox.setEnabled(autoReconnectCheckboxOverride.isSelected());
+            notifyOptionsChanged();
+        });
+
         if (inherited) {
             form
                     .addLabeledComponent(tlsCheckboxOverride, tlsCheckbox)
                     .addLabeledComponent(zipCheckboxOverride, zipCheckbox)
                     .addLabeledComponent(asyncCheckboxOverride, asyncCheckbox)
                     .addLabeledComponent(encodingCheckboxOverride, encodingPanel)
-                    .addLabeledComponent(timeoutSpinnerOverride, timeoutPanel);
+                    .addLabeledComponent(timeoutSpinnerOverride, timeoutPanel)
+                    .addLabeledComponent(heartbeatCheckboxOverride, heartbeatCheckbox)
+                    .addLabeledComponent(heartbeatIntervalOverride, heartbeatIntervalPanel)
+                    .addLabeledComponent(heartbeatTimeoutOverride, heartbeatTimeoutPanel)
+                    .addLabeledComponent(autoReconnectCheckboxOverride, autoReconnectCheckbox);
         } else {
             form
                     .addComponent(tlsCheckbox)
                     .addComponent(zipCheckbox)
                     .addComponent(asyncCheckbox)
                     .addComponent(encodingPanel)
-                    .addComponent(timeoutPanel);
+                    .addComponent(timeoutPanel)
+                    .addComponent(heartbeatCheckbox)
+                    .addComponent(heartbeatIntervalPanel)
+                    .addComponent(heartbeatTimeoutPanel)
+                    .addComponent(autoReconnectCheckbox);
         }
 
         form.addComponentFillVertically(new JPanel(), 0);
@@ -173,6 +223,22 @@ public class InstanceOptionsPanel extends JPanel {
         if (!inherited || encodingCheckboxOverride.isSelected()) {
             b.encoding(encodingCombobox.getItem());
         }
+
+        if (!inherited || heartbeatCheckboxOverride.isSelected()) {
+            b.heartbeat(heartbeatCheckbox.isSelected());
+        }
+
+        if (!inherited || heartbeatIntervalOverride.isSelected()) {
+            b.heartbeatInterval(heartbeatIntervalSpinner.getNumber());
+        }
+
+        if (!inherited || heartbeatTimeoutOverride.isSelected()) {
+            b.heartbeatTimeout(heartbeatTimeoutSpinner.getNumber());
+        }
+
+        if (!inherited || autoReconnectCheckboxOverride.isSelected()) {
+            b.autoReconnect(autoReconnectCheckbox.isSelected());
+        }
         return b.create();
     }
 
@@ -203,6 +269,28 @@ public class InstanceOptionsPanel extends JPanel {
         encodingLabel.setEnabled(!inherited || hasEncoding);
         encodingCombobox.setEnabled(!inherited || hasEncoding);
         encodingCombobox.setItem(hasEncoding ? options.getSafeEncoding() : parentOptions.getSafeEncoding());
+
+        final boolean hasHeartbeat = options != null && options.hasHeartbeat();
+        heartbeatCheckboxOverride.setSelected(hasHeartbeat);
+        heartbeatCheckbox.setEnabled(!inherited || hasHeartbeat);
+        heartbeatCheckbox.setSelected(hasHeartbeat ? options.isSafeHeartbeatEnabled() : parentOptions.isSafeHeartbeatEnabled());
+
+        final boolean hasHeartbeatInterval = options != null && options.hasHeartbeatInterval();
+        heartbeatIntervalOverride.setSelected(hasHeartbeatInterval);
+        heartbeatIntervalLabel.setEnabled(!inherited || hasHeartbeatInterval);
+        heartbeatIntervalSpinner.setEnabled(!inherited || hasHeartbeatInterval);
+        heartbeatIntervalSpinner.setValue(hasHeartbeatInterval ? options.getSafeHeartbeatIntervalSec() : parentOptions.getSafeHeartbeatIntervalSec());
+
+        final boolean hasHeartbeatTimeout = options != null && options.hasHeartbeatTimeout();
+        heartbeatTimeoutOverride.setSelected(hasHeartbeatTimeout);
+        heartbeatTimeoutLabel.setEnabled(!inherited || hasHeartbeatTimeout);
+        heartbeatTimeoutSpinner.setEnabled(!inherited || hasHeartbeatTimeout);
+        heartbeatTimeoutSpinner.setValue(hasHeartbeatTimeout ? options.getSafeHeartbeatTimeoutMs() : parentOptions.getSafeHeartbeatTimeoutMs());
+
+        final boolean hasAutoReconnect = options != null && options.hasAutoReconnect();
+        autoReconnectCheckboxOverride.setSelected(hasAutoReconnect);
+        autoReconnectCheckbox.setEnabled(!inherited || hasAutoReconnect);
+        autoReconnectCheckbox.setSelected(hasAutoReconnect ? options.isSafeAutoReconnect() : parentOptions.isSafeAutoReconnect());
     }
 
     protected void notifyOptionsChanged() {

--- a/src/main/java/org/kdb/inside/brains/core/KdbConnectionManager.java
+++ b/src/main/java/org/kdb/inside/brains/core/KdbConnectionManager.java
@@ -56,7 +56,13 @@ public class KdbConnectionManager implements Disposable, DumbAware {
     private final ScheduledExecutorService connectionProgressExecutor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "KdbConnectionManager-ProgressUpdater"));
 
     private final ConnectionHealthMonitor healthMonitor = new ConnectionHealthMonitor(
-            (connection, reason) -> ((TheInstanceConnection) connection).close(reason),
+            (connection, kx, reason) -> ((TheInstanceConnection) connection).closeIfCurrent(kx, reason),
+            connection -> {
+                // reconnect only connections this manager still tracks
+                if (connections.get(connection.getInstance()) == connection) {
+                    connection.connect();
+                }
+            },
             command -> ApplicationManager.getApplication().invokeLater(command)
     );
 
@@ -416,15 +422,21 @@ public class KdbConnectionManager implements Disposable, DumbAware {
     }
 
     private class TheInstanceConnection implements InstanceConnection {
-        private Exception error;
-        private InstanceState state;
-        private long stateChangeTime;
+        // volatile: read from heartbeat/watchdog/reconnect threads, mutated under stateLock
+        private volatile Exception error;
+        private volatile InstanceState state;
+        private volatile long stateChangeTime;
 
-        private KxConnection myConnection;
+        private volatile KxConnection myConnection;
         // volatile: read by the heartbeat thread to skip probing while a user query is in flight
         private volatile QueryProgressive queryProgressive;
 
         private final KdbInstance instance;
+
+        // guards state/error/stateChangeTime/myConnection transitions so that concurrent closes
+        // (user disconnect, failed query, heartbeat death) produce exactly one DISCONNECTED
+        // transition; never held while notifying listeners or the health monitor
+        private final Object stateLock = new Object();
 
         TheInstanceConnection(KdbInstance instance) {
             this.instance = instance;
@@ -533,51 +545,84 @@ public class KdbConnectionManager implements Disposable, DumbAware {
         }
 
         void connecting() {
-            updateState(InstanceState.CONNECTING);
+            final InstanceState oldState;
+            synchronized (stateLock) {
+                oldState = state;
+                state = InstanceState.CONNECTING;
+                error = null;
+                stateChangeTime = System.currentTimeMillis();
+            }
+            fireStateChanged(oldState, InstanceState.CONNECTING);
         }
 
         void connected(KxConnection connection) {
-            this.myConnection = connection;
-            updateState(InstanceState.CONNECTED);
+            final InstanceState oldState;
+            synchronized (stateLock) {
+                this.myConnection = connection;
+                oldState = state;
+                state = InstanceState.CONNECTED;
+                error = null;
+                stateChangeTime = System.currentTimeMillis();
+            }
 
-            // Monitor only registered connections - test() connections are throw-away
+            // Monitor only registered connections - test() connections are throw-away. Registered
+            // before the (potentially blocking) listener broadcast so that a concurrent error close
+            // always finds the monitored entry and can schedule an auto-reconnect.
             if (connections.get(instance) == this) {
                 healthMonitor.connectionOpened(this, connection, InstanceOptions.resolveOptions(instance));
             }
+            fireStateChanged(oldState, InstanceState.CONNECTED);
         }
 
 
         void close(Exception exception) {
-            if (myConnection != null) {
-                myConnection.close();
+            close(null, exception);
+        }
+
+        /**
+         * Closes the connection only when {@code expected} is still its current transport: a stale
+         * death report from a heartbeat that probed an old, already replaced KxConnection must not
+         * kill a freshly re-established connection.
+         */
+        void closeIfCurrent(KxConnection expected, Exception exception) {
+            close(expected, exception);
+        }
+
+        private void close(KxConnection expected, Exception exception) {
+            final KxConnection connection;
+            final InstanceState oldState;
+            synchronized (stateLock) {
+                if (expected != null && myConnection != expected) {
+                    return; // stale death report - the transport was already replaced or closed
+                }
+                connection = myConnection;
                 myConnection = null;
+                oldState = state;
+                if (oldState != InstanceState.DISCONNECTED) {
+                    state = InstanceState.DISCONNECTED;
+                    error = exception;
+                    stateChangeTime = System.currentTimeMillis();
+                }
             }
 
-            if (state != InstanceState.DISCONNECTED) {
-                updateState(InstanceState.DISCONNECTED, exception);
+            if (connection != null) {
+                connection.close();
+            }
 
-                // Only on a real transition: a late close(ex) on an already disconnected instance
-                // must not schedule reconnect attempts
+            // Only on a real transition: a late close(ex) on an already disconnected instance must
+            // neither re-notify listeners nor schedule reconnect attempts
+            if (oldState != InstanceState.DISCONNECTED) {
                 if (connections.get(instance) == this) {
                     healthMonitor.connectionClosed(this, exception, InstanceOptions.resolveOptions(instance));
                 }
+                fireStateChanged(oldState, InstanceState.DISCONNECTED);
             }
         }
 
-        private void updateState(InstanceState newState) {
-            updateState(newState, null);
-        }
-
-        private void updateState(InstanceState newState, Exception exception) {
-            InstanceState oldState = state;
-
-            state = newState;
-            error = exception;
-            stateChangeTime = System.currentTimeMillis();
-
+        private void fireStateChanged(InstanceState oldState, InstanceState newState) {
             // Notify only if contains - test is not in the scope, for example
             if (connections.containsKey(instance)) {
-                processConnectionState(this, oldState, state);
+                processConnectionState(this, oldState, newState);
             }
         }
 

--- a/src/main/java/org/kdb/inside/brains/core/KdbConnectionManager.java
+++ b/src/main/java/org/kdb/inside/brains/core/KdbConnectionManager.java
@@ -55,6 +55,11 @@ public class KdbConnectionManager implements Disposable, DumbAware {
 
     private final ScheduledExecutorService connectionProgressExecutor = Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "KdbConnectionManager-ProgressUpdater"));
 
+    private final ConnectionHealthMonitor healthMonitor = new ConnectionHealthMonitor(
+            (connection, reason) -> ((TheInstanceConnection) connection).close(reason),
+            command -> ApplicationManager.getApplication().invokeLater(command)
+    );
+
     public KdbConnectionManager(Project project) {
         this.project = project;
         this.queryLogger = project.getService(KdbQueryLogger.class);
@@ -112,6 +117,7 @@ public class KdbConnectionManager implements Disposable, DumbAware {
         final TheInstanceConnection conn = connections.remove(instance);
         if (conn != null) {
             conn.disconnect();
+            healthMonitor.connectionRemoved(conn);
             processConnectionRemoved(conn);
         }
         return conn;
@@ -148,6 +154,8 @@ public class KdbConnectionManager implements Disposable, DumbAware {
     @Override
     public void dispose() {
         connectionListeners.clear();
+
+        healthMonitor.dispose();
 
         connections.values().forEach(TheInstanceConnection::disconnect);
         connections.clear();
@@ -413,7 +421,8 @@ public class KdbConnectionManager implements Disposable, DumbAware {
         private long stateChangeTime;
 
         private KxConnection myConnection;
-        private QueryProgressive queryProgressive;
+        // volatile: read by the heartbeat thread to skip probing while a user query is in flight
+        private volatile QueryProgressive queryProgressive;
 
         private final KdbInstance instance;
 
@@ -493,6 +502,10 @@ public class KdbConnectionManager implements Disposable, DumbAware {
 
         @Override
         public void disconnect() {
+            // cancels pending auto-reconnect attempts even when the connection is already
+            // DISCONNECTED and just waiting for the next retry
+            healthMonitor.reconnectAborted(this);
+
             if (!state.isDisconnectable()) {
                 return;
             }
@@ -526,6 +539,11 @@ public class KdbConnectionManager implements Disposable, DumbAware {
         void connected(KxConnection connection) {
             this.myConnection = connection;
             updateState(InstanceState.CONNECTED);
+
+            // Monitor only registered connections - test() connections are throw-away
+            if (connections.get(instance) == this) {
+                healthMonitor.connectionOpened(this, connection, InstanceOptions.resolveOptions(instance));
+            }
         }
 
 
@@ -537,6 +555,12 @@ public class KdbConnectionManager implements Disposable, DumbAware {
 
             if (state != InstanceState.DISCONNECTED) {
                 updateState(InstanceState.DISCONNECTED, exception);
+
+                // Only on a real transition: a late close(ex) on an already disconnected instance
+                // must not schedule reconnect attempts
+                if (connections.get(instance) == this) {
+                    healthMonitor.connectionClosed(this, exception, InstanceOptions.resolveOptions(instance));
+                }
             }
         }
 

--- a/src/main/java/org/kdb/inside/brains/settings/KdbSettingsService.java
+++ b/src/main/java/org/kdb/inside/brains/settings/KdbSettingsService.java
@@ -211,6 +211,9 @@ public class KdbSettingsService implements PersistentStateComponent<KdbSettingsS
 
         public void setInstanceOptions(InstanceOptions instanceOptions) {
             this.instanceOptions.copyFrom(instanceOptions);
+            // the application-level options are the inheritance root and must stay fully populated;
+            // settings persisted by an older plugin version lack the newer attributes
+            this.instanceOptions.fillAbsentWithDefaults();
         }
 
         public EditorOptions getEditorOptions() {

--- a/src/test/java/org/kdb/inside/brains/core/ConnectionHealthMonitorTest.java
+++ b/src/test/java/org/kdb/inside/brains/core/ConnectionHealthMonitorTest.java
@@ -34,7 +34,7 @@ class ConnectionHealthMonitorTest {
     @BeforeEach
     void setUp() {
         deadHandler = mock(ConnectionHealthMonitor.DeadConnectionHandler.class);
-        monitor = new ConnectionHealthMonitor(deadHandler, Runnable::run);
+        monitor = new ConnectionHealthMonitor(deadHandler, InstanceConnection::connect, Runnable::run);
     }
 
     @AfterEach
@@ -78,6 +78,7 @@ class ConnectionHealthMonitorTest {
         assertTrue(monitor.runHeartbeatNow(connection));
 
         assertTrue(server.awaitMessages(1, 2000), "the server never received the probe");
+        assertEquals(10, server.lastPayloadType(), "the probe must be a char-vector expression (type 10), not a symbol");
         verifyNoInteractions(deadHandler);
         assertTrue(kx.isConnected());
     }
@@ -104,7 +105,7 @@ class ConnectionHealthMonitorTest {
         assertTrue(monitor.runHeartbeatNow(connection)); // blocks until the watchdog closes the socket
         final long elapsed = System.currentTimeMillis() - start;
 
-        verify(deadHandler, times(1)).connectionDead(same(connection), any(IOException.class));
+        verify(deadHandler, timeout(2000).times(1)).connectionDead(same(connection), same(kx), any(IOException.class));
         assertTrue(elapsed >= InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS / 2, "died suspiciously fast: " + elapsed + "ms");
         assertTrue(elapsed < InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS * 20L, "watchdog did not fire in time: " + elapsed + "ms");
     }
@@ -173,6 +174,21 @@ class ConnectionHealthMonitorTest {
     }
 
     @Test
+    void errorCloseAfterAbortDoesNotReconnect() throws Exception {
+        final InstanceConnection connection = mockConnection();
+        when(connection.getState()).thenReturn(InstanceState.DISCONNECTED);
+
+        final InstanceOptions options = healthOptions().heartbeat(false).autoReconnect(true).create();
+        monitor.connectionOpened(connection, mock(KxConnection.class), options);
+        monitor.reconnectAborted(connection); // user disconnected: the entry is gone
+
+        // a later failed manual connect attempt must not start the retry loop
+        monitor.connectionClosed(connection, new IOException("boom"), options);
+        Thread.sleep(3000);
+        verify(connection, never()).connect();
+    }
+
+    @Test
     void intentionalCloseDoesNotReconnect() throws Exception {
         final InstanceConnection connection = mockConnection();
         when(connection.getState()).thenReturn(InstanceState.DISCONNECTED);
@@ -222,6 +238,7 @@ class ConnectionHealthMonitorTest {
         private final ServerSocket serverSocket;
         private final Thread thread;
         private final AtomicInteger messages = new AtomicInteger();
+        private final AtomicInteger lastPayloadType = new AtomicInteger(Integer.MIN_VALUE);
         private final CopyOnWriteArrayList<CountDownLatch> waiters = new CopyOnWriteArrayList<>();
 
         FakeKdbServer(Behaviour behaviour) throws IOException {
@@ -233,6 +250,10 @@ class ConnectionHealthMonitorTest {
 
         int port() {
             return serverSocket.getLocalPort();
+        }
+
+        int lastPayloadType() {
+            return lastPayloadType.get();
         }
 
         boolean awaitMessages(int count, long timeoutMs) throws InterruptedException {
@@ -270,7 +291,11 @@ class ConnectionHealthMonitorTest {
                     final int size = header[0] == 1
                             ? (header[4] & 0xFF) | (header[5] & 0xFF) << 8 | (header[6] & 0xFF) << 16 | (header[7] & 0xFF) << 24
                             : (header[7] & 0xFF) | (header[6] & 0xFF) << 8 | (header[5] & 0xFF) << 16 | (header[4] & 0xFF) << 24;
-                    readFully(in, new byte[size - 8]);
+                    final byte[] body = new byte[size - 8];
+                    readFully(in, body);
+                    if (body.length > 0) {
+                        lastPayloadType.set(body[0]);
+                    }
 
                     messages.incrementAndGet();
                     waiters.forEach(CountDownLatch::countDown);

--- a/src/test/java/org/kdb/inside/brains/core/ConnectionHealthMonitorTest.java
+++ b/src/test/java/org/kdb/inside/brains/core/ConnectionHealthMonitorTest.java
@@ -1,0 +1,314 @@
+package org.kdb.inside.brains.core;
+
+import kx.KxConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Exercises the heartbeat/watchdog/auto-reconnect logic against a fake kdb+ server speaking just
+ * enough of the IPC protocol: handshake, canned responses to probe messages, and - for the
+ * dead-connection cases - accepting a probe and never answering.
+ */
+class ConnectionHealthMonitorTest {
+    private FakeKdbServer server;
+    private KxConnection kx;
+    private ConnectionHealthMonitor monitor;
+    private ConnectionHealthMonitor.DeadConnectionHandler deadHandler;
+
+    @BeforeEach
+    void setUp() {
+        deadHandler = mock(ConnectionHealthMonitor.DeadConnectionHandler.class);
+        monitor = new ConnectionHealthMonitor(deadHandler, Runnable::run);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        monitor.dispose();
+        if (kx != null) {
+            kx.close();
+        }
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    private InstanceConnection mockConnection() {
+        final InstanceConnection connection = mock(InstanceConnection.class);
+        when(connection.getState()).thenReturn(InstanceState.CONNECTED);
+        when(connection.getQuery()).thenReturn(null);
+        when(connection.getName()).thenReturn("mock");
+        return connection;
+    }
+
+    private InstanceConnection connect(FakeKdbServer.Behaviour behaviour) throws Exception {
+        server = new FakeKdbServer(behaviour);
+        kx = new KxConnection("localhost", server.port(), false, false, false, "UTF-8");
+        kx.authenticate("test:test");
+        return mockConnection();
+    }
+
+    private static InstanceOptions.Builder healthOptions() {
+        return new InstanceOptions.Builder()
+                .heartbeat(true)
+                .heartbeatInterval(InstanceOptions.MIN_HEARTBEAT_INTERVAL_SEC)
+                .heartbeatTimeout(InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS);
+    }
+
+    @Test
+    void probeCompletesOnAliveConnection() throws Exception {
+        final InstanceConnection connection = connect(FakeKdbServer.Behaviour.RESPOND_IDENTITY);
+
+        monitor.connectionOpened(connection, kx, healthOptions().create());
+        assertTrue(monitor.runHeartbeatNow(connection));
+
+        assertTrue(server.awaitMessages(1, 2000), "the server never received the probe");
+        verifyNoInteractions(deadHandler);
+        assertTrue(kx.isConnected());
+    }
+
+    @Test
+    void errorResponseMeansConnectionIsAlive() throws Exception {
+        final InstanceConnection connection = connect(FakeKdbServer.Behaviour.RESPOND_ERROR);
+
+        monitor.connectionOpened(connection, kx, healthOptions().create());
+        assertTrue(monitor.runHeartbeatNow(connection));
+
+        assertTrue(server.awaitMessages(1, 2000));
+        verifyNoInteractions(deadHandler);
+        assertTrue(kx.isConnected());
+    }
+
+    @Test
+    void stalledProbeIsKilledByWatchdogAndReportedDead() throws Exception {
+        final InstanceConnection connection = connect(FakeKdbServer.Behaviour.NEVER_RESPOND);
+
+        monitor.connectionOpened(connection, kx, healthOptions().create());
+
+        final long start = System.currentTimeMillis();
+        assertTrue(monitor.runHeartbeatNow(connection)); // blocks until the watchdog closes the socket
+        final long elapsed = System.currentTimeMillis() - start;
+
+        verify(deadHandler, times(1)).connectionDead(same(connection), any(IOException.class));
+        assertTrue(elapsed >= InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS / 2, "died suspiciously fast: " + elapsed + "ms");
+        assertTrue(elapsed < InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS * 20L, "watchdog did not fire in time: " + elapsed + "ms");
+    }
+
+    @Test
+    void probeIsSkippedWhileUserQueryInFlight() throws Exception {
+        final InstanceConnection connection = connect(FakeKdbServer.Behaviour.NEVER_RESPOND);
+        when(connection.getQuery()).thenReturn(mock(KdbQuery.class));
+
+        monitor.connectionOpened(connection, kx, healthOptions().create());
+        assertTrue(monitor.runHeartbeatNow(connection)); // must return immediately without probing
+
+        assertFalse(server.awaitMessages(1, 300), "no probe may be sent while a query is in flight");
+        verifyNoInteractions(deadHandler);
+        assertTrue(kx.isConnected());
+    }
+
+    @Test
+    void heartbeatDisabledSchedulesNothing() throws Exception {
+        final InstanceConnection connection = connect(FakeKdbServer.Behaviour.RESPOND_IDENTITY);
+
+        monitor.connectionOpened(connection, kx, healthOptions().heartbeat(false).create());
+        assertTrue(monitor.runHeartbeatNow(connection)); // manually forced tick still probes; scheduling is off
+
+        // the important part: options with heartbeat disabled do not create the periodic task;
+        // there is no API to inspect the scheduler, so this test just documents the manual tick
+        verifyNoInteractions(deadHandler);
+    }
+
+    @Test
+    void asyncConnectionIsNeverProbed() throws Exception {
+        final InstanceConnection connection = connect(FakeKdbServer.Behaviour.NEVER_RESPOND);
+
+        monitor.connectionOpened(connection, kx, healthOptions().async(true).create());
+        // no periodic task is scheduled for async connections; a forced tick still exists but the
+        // scheduled path is what production uses - wait and check no probe arrived on its own
+        assertFalse(server.awaitMessages(1, 500), "async connections must not be probed by the scheduler");
+        verifyNoInteractions(deadHandler);
+    }
+
+    @Test
+    void autoReconnectRetriesAfterFailure() throws Exception {
+        final InstanceConnection connection = mockConnection();
+        when(connection.getState()).thenReturn(InstanceState.DISCONNECTED);
+
+        final InstanceOptions options = healthOptions().heartbeat(false).autoReconnect(true).create();
+        monitor.connectionOpened(connection, mock(KxConnection.class), options);
+        monitor.connectionClosed(connection, new IOException("boom"), options);
+
+        // first backoff step is 2s
+        verify(connection, timeout(4000).times(1)).connect();
+    }
+
+    @Test
+    void manualDisconnectCancelsPendingReconnect() throws Exception {
+        final InstanceConnection connection = mockConnection();
+        when(connection.getState()).thenReturn(InstanceState.DISCONNECTED);
+
+        final InstanceOptions options = healthOptions().heartbeat(false).autoReconnect(true).create();
+        monitor.connectionOpened(connection, mock(KxConnection.class), options);
+        monitor.connectionClosed(connection, new IOException("boom"), options);
+        monitor.reconnectAborted(connection);
+
+        Thread.sleep(3000);
+        verify(connection, never()).connect();
+    }
+
+    @Test
+    void intentionalCloseDoesNotReconnect() throws Exception {
+        final InstanceConnection connection = mockConnection();
+        when(connection.getState()).thenReturn(InstanceState.DISCONNECTED);
+
+        final InstanceOptions options = healthOptions().heartbeat(false).autoReconnect(true).create();
+        monitor.connectionOpened(connection, mock(KxConnection.class), options);
+        monitor.connectionClosed(connection, null, options);
+
+        Thread.sleep(3000);
+        verify(connection, never()).connect();
+    }
+
+    @Test
+    void reconnectDisabledDoesNothing() throws Exception {
+        final InstanceConnection connection = mockConnection();
+        when(connection.getState()).thenReturn(InstanceState.DISCONNECTED);
+
+        final InstanceOptions options = healthOptions().heartbeat(false).create(); // autoReconnect defaults to false
+        monitor.connectionOpened(connection, mock(KxConnection.class), options);
+        monitor.connectionClosed(connection, new IOException("boom"), options);
+
+        Thread.sleep(3000);
+        verify(connection, never()).connect();
+    }
+
+    @Test
+    void unknownConnectionIsIgnored() {
+        final InstanceConnection connection = mockConnection();
+        assertFalse(monitor.runHeartbeatNow(connection));
+        // a close for a never-opened connection (e.g. the very first connect failed) must not retry
+        monitor.connectionClosed(connection, new IOException("boom"), healthOptions().autoReconnect(true).create());
+        verify(connection, after(2500).never()).connect();
+    }
+
+    /**
+     * Accepts a single connection, performs the kdb+ handshake (credentials until {@code \0},
+     * replies protocol version 3) and then serves incoming messages according to the behaviour.
+     */
+    private static final class FakeKdbServer implements AutoCloseable {
+        enum Behaviour {RESPOND_IDENTITY, RESPOND_ERROR, NEVER_RESPOND}
+
+        // (1;`response;0;0) header + payload `::` (101 0x00)
+        private static final byte[] IDENTITY_RESPONSE = {1, 2, 0, 0, 10, 0, 0, 0, 101, 0};
+        // -128 followed by "boom\0"
+        private static final byte[] ERROR_RESPONSE = {1, 2, 0, 0, 14, 0, 0, 0, (byte) 0x80, 'b', 'o', 'o', 'm', 0};
+
+        private final ServerSocket serverSocket;
+        private final Thread thread;
+        private final AtomicInteger messages = new AtomicInteger();
+        private final CopyOnWriteArrayList<CountDownLatch> waiters = new CopyOnWriteArrayList<>();
+
+        FakeKdbServer(Behaviour behaviour) throws IOException {
+            serverSocket = new ServerSocket(0);
+            thread = new Thread(() -> serve(behaviour), "fake-kdb-server");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        int port() {
+            return serverSocket.getLocalPort();
+        }
+
+        boolean awaitMessages(int count, long timeoutMs) throws InterruptedException {
+            final CountDownLatch latch = new CountDownLatch(Math.max(0, count - messages.get()));
+            waiters.add(latch);
+            try {
+                return latch.await(timeoutMs, TimeUnit.MILLISECONDS);
+            } finally {
+                waiters.remove(latch);
+            }
+        }
+
+        private void serve(Behaviour behaviour) {
+            try (Socket socket = serverSocket.accept()) {
+                final InputStream in = socket.getInputStream();
+                final OutputStream out = socket.getOutputStream();
+
+                // handshake: credentials + version byte, null-terminated; reply with version 3
+                final ByteArrayOutputStream credentials = new ByteArrayOutputStream();
+                int c;
+                while ((c = in.read()) > 0) {
+                    credentials.write(c);
+                }
+                if (c < 0) {
+                    return;
+                }
+                out.write(3);
+                out.flush();
+
+                // message loop: 8 byte header, size at offset 4 with endianness declared by byte 0
+                // (this c.java fork serializes outgoing messages big-endian with header[0] == 0)
+                final byte[] header = new byte[8];
+                while (true) {
+                    readFully(in, header);
+                    final int size = header[0] == 1
+                            ? (header[4] & 0xFF) | (header[5] & 0xFF) << 8 | (header[6] & 0xFF) << 16 | (header[7] & 0xFF) << 24
+                            : (header[7] & 0xFF) | (header[6] & 0xFF) << 8 | (header[5] & 0xFF) << 16 | (header[4] & 0xFF) << 24;
+                    readFully(in, new byte[size - 8]);
+
+                    messages.incrementAndGet();
+                    waiters.forEach(CountDownLatch::countDown);
+
+                    switch (behaviour) {
+                        case RESPOND_IDENTITY -> {
+                            out.write(IDENTITY_RESPONSE);
+                            out.flush();
+                        }
+                        case RESPOND_ERROR -> {
+                            out.write(ERROR_RESPONSE);
+                            out.flush();
+                        }
+                        case NEVER_RESPOND -> {
+                            // sit on it
+                        }
+                    }
+                }
+            } catch (IOException ignore) {
+                // client gone - test over
+            }
+        }
+
+        private static void readFully(InputStream in, byte[] buffer) throws IOException {
+            int read = 0;
+            while (read < buffer.length) {
+                final int n = in.read(buffer, read, buffer.length - read);
+                if (n < 0) {
+                    throw new IOException("Connection closed");
+                }
+                read += n;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+            thread.interrupt();
+        }
+    }
+}

--- a/src/test/java/org/kdb/inside/brains/core/InstanceOptionsTest.java
+++ b/src/test/java/org/kdb/inside/brains/core/InstanceOptionsTest.java
@@ -88,6 +88,72 @@ class InstanceOptionsTest {
     }
 
     @Test
+    void builderHealthOptions() {
+        final InstanceOptions.Builder b = new InstanceOptions.Builder();
+        InstanceOptions o = b.create();
+        assertFalse(o.hasHeartbeat());
+        assertTrue(o.isSafeHeartbeatEnabled());
+        assertFalse(o.hasHeartbeatInterval());
+        assertEquals(InstanceOptions.DEFAULT_HEARTBEAT_INTERVAL_SEC, o.getSafeHeartbeatIntervalSec());
+        assertFalse(o.hasHeartbeatTimeout());
+        assertEquals(InstanceOptions.DEFAULT_HEARTBEAT_TIMEOUT_MS, o.getSafeHeartbeatTimeoutMs());
+        assertFalse(o.hasAutoReconnect());
+        assertFalse(o.isSafeAutoReconnect());
+
+        b.heartbeat(false).heartbeatInterval(10).heartbeatTimeout(2000).autoReconnect(true);
+        o = b.create();
+        assertTrue(o.hasHeartbeat());
+        assertFalse(o.isSafeHeartbeatEnabled());
+        assertTrue(o.hasHeartbeatInterval());
+        assertEquals(10, o.getSafeHeartbeatIntervalSec());
+        assertTrue(o.hasHeartbeatTimeout());
+        assertEquals(2000, o.getSafeHeartbeatTimeoutMs());
+        assertTrue(o.hasAutoReconnect());
+        assertTrue(o.isSafeAutoReconnect());
+
+        assertThrows(IllegalArgumentException.class, () -> new InstanceOptions.Builder().heartbeatInterval(InstanceOptions.MIN_HEARTBEAT_INTERVAL_SEC - 1));
+        assertThrows(IllegalArgumentException.class, () -> new InstanceOptions.Builder().heartbeatTimeout(InstanceOptions.MIN_HEARTBEAT_TIMEOUT_MS - 1));
+    }
+
+    @Test
+    void parametersHealthOptions() {
+        final InstanceOptions o = InstanceOptions.fromParameters("heartbeat=false&heartbeatInterval=15&heartbeatTimeout=3000&autoReconnect=true");
+        assertTrue(o.hasHeartbeat());
+        assertFalse(o.isSafeHeartbeatEnabled());
+        assertEquals(15, o.getSafeHeartbeatIntervalSec());
+        assertEquals(3000, o.getSafeHeartbeatTimeoutMs());
+        assertTrue(o.isSafeAutoReconnect());
+        assertEquals("heartbeat=false&heartbeatInterval=15&heartbeatTimeout=3000&autoReconnect=true", o.toParameters());
+    }
+
+    @Test
+    void xmlHealthOptions() {
+        final Element e = new Element("mock");
+
+        final InstanceOptions.Builder b = new InstanceOptions.Builder();
+        b.heartbeat(true).heartbeatInterval(20).heartbeatTimeout(1500).autoReconnect(true);
+        b.create().store(e);
+        assertEquals("true", e.getAttributeValue("heartbeat"));
+        assertEquals("20", e.getAttributeValue("heartbeatInterval"));
+        assertEquals("1500", e.getAttributeValue("heartbeatTimeout"));
+        assertEquals("true", e.getAttributeValue("autoReconnect"));
+        assertEquals(b.create(), InstanceOptions.restore(e));
+    }
+
+    @Test
+    void safeHealthOptions() {
+        final InstanceOptions o = new InstanceOptions.Builder().safe().create();
+        assertTrue(o.hasHeartbeat());
+        assertTrue(o.isSafeHeartbeatEnabled());
+        assertTrue(o.hasHeartbeatInterval());
+        assertEquals(InstanceOptions.DEFAULT_HEARTBEAT_INTERVAL_SEC, o.getSafeHeartbeatIntervalSec());
+        assertTrue(o.hasHeartbeatTimeout());
+        assertEquals(InstanceOptions.DEFAULT_HEARTBEAT_TIMEOUT_MS, o.getSafeHeartbeatTimeoutMs());
+        assertTrue(o.hasAutoReconnect());
+        assertFalse(o.isSafeAutoReconnect());
+    }
+
+    @Test
     void parameters() {
         final InstanceOptions o1 = InstanceOptions.INHERITED;
         assertSame(o1, InstanceOptions.fromParameters(null));


### PR DESCRIPTION
## Problem

A long-lived connection to a remote kdb+ instance can die **silently**: the laptop sleeps, the network path re-asserts (VPN/ZTNA gateway, Wi-Fi roam, NAT timeout), and the plugin-owned TCP connection is orphaned without the remote ever sending FIN or RST. Nothing detects the death — `DataInputStream.readFully` has no SO_TIMEOUT, so reader threads and `KdbConnectionManager` park indefinitely. The instance still shows green, every query hangs, and the only recourse is restarting the IDE.

The plugin already calls `setKeepAlive(true)` in `kx/c.java#io(Socket)`, but that uses OS default timings — on macOS the first keepalive probe is sent after **2 hours** idle (`net.inet.tcp.keepidle`), i.e. effectively never for this failure mode.

## Fix (three layers, each commit reviewable on its own)

**1. Tuned TCP keepalive** (`kx/c.java`, ~15 lines)
Best-effort via `jdk.net.ExtendedSocketOptions` (JDK 11+, macOS/Linux): first probe after 30 s idle, then every 10 s, dead after 3 unanswered probes. A silently dead connection is declared by the kernel within ~60 s and the parked read fails with `IOException` into the existing disconnect handling. Unsupported platforms keep OS defaults. Passive — covers all connections, including async ones and in-flight user queries.

**2. Idle heartbeat + stalled-read watchdog** (new `core/ConnectionHealthMonitor`, `KxConnection.probe(...)`)
While a connection is idle, a side-effect-free sync probe (char-vector `"::"`) runs every `heartbeatInterval` s. A watchdog on a dedicated thread force-closes the socket when a probe gets no response within `heartbeatTimeout` ms, which unblocks the read and flows into the normal error handling — the instance turns red exactly like a regular connection loss (detection ≤ ~35 s with defaults).

Correctness notes:
- The probe performs its whole write+read under **both** stream locks (`o` then `i`), so it can never interleave with `query(...)`; the "query in flight" check is re-validated after the locks are held, so a concurrent user query always wins and the probe skips.
- Watchdog vs. probe-completion is arbitrated by an atomic CAS — `ScheduledFuture.cancel()` alone can report success while the task body is already running.
- Async-mode connections are never probed (a probe response could be mistaken for a pending async reply); they are covered by layer 1.
- With the heartbeat option off, no task is ever scheduled and code paths are identical to current behaviour.

**3. Optional auto-reconnect** (default **off**)
When a previously established connection dies with an error and `autoReconnect` is enabled: retry with 2/5/10/30 s backoff, capped at 20 attempts; cancelled by manual disconnect, instance removal, or success. Reuses the existing `connect()` path so listeners/notifications behave as for a manual reconnect. Retry tasks carry a generation number re-validated after the timer fires and again on the EDT, so a manual disconnect reliably aborts even a retry that already left the scheduler queue.

**Options** follow the existing `InstanceOptions` builder/XML/`resolve()` inheritance pattern and appear in the Connection Options panel (global / scope / instance): `heartbeat` (default on), `heartbeatInterval` (30 s), `heartbeatTimeout` (5000 ms), `autoReconnect` (default off). Configurations written by older versions load unchanged.

The third commit also hardens pre-existing close-races that this feature would otherwise widen: `KxConnection.close()` is now double-close safe, `query()`/`serialize()`/`deserialize()` surface a concurrent close as `IOException("Connection lost")` instead of an NPE, and `TheInstanceConnection` state transitions are serialized so concurrent closes produce exactly one DISCONNECTED transition.

## Testing

- `./gradlew test` passes.
- New `ConnectionHealthMonitorTest` exercises the real IPC byte flow against an in-process fake kdb+ server (handshake + canned responses): probe round-trip, error response treated as alive, watchdog kill on a stalled probe, probe skipped while a user query is in flight, reconnect backoff/cancellation semantics.
- `InstanceOptionsTest` extended for the new options (builder validation, XML and URL-parameter round-trips, `safe()` defaults).
- Manually validated in `runIde` against a remote q instance: `kill -STOP` on the remote q (stalls traffic without FIN) turns the instance red within the configured timeout instead of hanging the IDE; the real morning-after-sleep scenario recovers with one click (or automatically with auto-reconnect on).

Happy to split this into separate PRs (keepalive first) or adjust naming/defaults — whatever fits the project best. CHANGELOG entries left out intentionally; can add on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
